### PR TITLE
Added getSid() for active call

### DIFF
--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -406,7 +406,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             this.mute(muted);
             result.success(true);
         } else if (call.method.equals("call-sid")) {
-            return result.success(activeCall.getSid());
+            result.success(activeCall.getSid());
         } else if (call.method.equals("isOnCall")) {
             Log.d(TAG, "Is on call invoked");
             result.success(this.activeCall != null);

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -406,7 +406,7 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             this.mute(muted);
             result.success(true);
         } else if (call.method.equals("call-sid")) {
-            result.success(activeCall.getSid());
+            result.success(activeCall == null ? null : activeCall.getSid());
         } else if (call.method.equals("isOnCall")) {
             Log.d(TAG, "Is on call invoked");
             result.success(this.activeCall != null);

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -405,6 +405,8 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             Log.d(TAG, "Muting call");
             this.mute(muted);
             result.success(true);
+        } else if (call.method.equals("call-sid")) {
+            return result.success(activeCall.getSid());
         } else if (call.method.equals("isOnCall")) {
             Log.d(TAG, "Is on call invoked");
             result.success(this.activeCall != null);
@@ -442,28 +444,37 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
         } else if (call.method.equals("registerClient")) {
             String id = call.argument("id");
             String name = call.argument("name");
+            boolean added = false;
             if (id != null && name != null && !pSharedPref.contains(id)) {
                 sendPhoneCallEvents("LOG|Registering client " + id + ":" + name);
                 SharedPreferences.Editor edit = pSharedPref.edit();
                 edit.putString(id, name);
                 edit.apply();
+                added = true;
             }
+            result.success(added);
         } else if (call.method.equals("unregisterClient")) {
             String id = call.argument("id");
+            boolean added = false;
             if (id != null) {
-                sendPhoneCallEvents("LOG|Unegistering" + id);
+                sendPhoneCallEvents("LOG|Unregistering" + id);
                 SharedPreferences.Editor edit = pSharedPref.edit();
                 edit.remove(id);
                 edit.apply();
+                added = true;
             }
+            result.success(added);
         } else if (call.method.equals("defaultCaller")) {
             String caller = call.argument("defaultCaller");
+            boolean added = false;
             if (caller != null) {
                 sendPhoneCallEvents("LOG|defaultCaller is " + caller);
                 SharedPreferences.Editor edit = pSharedPref.edit();
                 edit.putString("defaultCaller", caller);
                 edit.apply();
+                added = true;
             }
+            result.success(added);
         } else if (call.method.equals("hasMicPermission")) {
             result.success(this.checkPermissionForMicrophone());
         } else if (call.method.equals("requestMicPermission")) {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -156,7 +156,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
         else if flutterCall.method == "call-sid"
         {
-            result(self.call!.sid);
+            result(self.call == nil ? nil : self.call!.sid);
             return;
         }
         else if flutterCall.method == "isOnCall"

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -154,6 +154,11 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
             eventSink(speakerIsOn ? "Speaker On" : "Speaker Off")
         }
+        else if flutterCall.method == "call-sid"
+        {
+            result(self.call!.sid);
+            return;
+        }
         else if flutterCall.method == "isOnCall"
         {
             result(self.call != nil);

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -245,6 +245,11 @@ class Call {
         <String, dynamic>{}).then<bool>((bool? value) => value ?? false);
   }
 
+  /// Gets the active call's SID. This will be null until the first Ringing event occurs
+  Future<String?> getSid() {
+    return _channel.invokeMethod<String?>('call-sid', <String, dynamic>{}).then<String?>((String? value) => value);
+  }
+
   /// Answers incoming call
   Future<bool?> answer() {
     return _channel.invokeMethod('answer', <String, dynamic>{});


### PR DESCRIPTION
This helps uniquely identify and match call to Twilio records as there is currently no unique identifier put in place and at the time of creating PR, the customParamaters isn't working correctly.