### PR TITLE
feat: Add Handset State query 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next release
 * Feat: [Android] Turn off the screen when a call is active and the head is against the handset. @solid-software (https://solid.software)
+* Feat: [Android, iOS] Add handset call status: `isMuted()`, `isOnSpeaker()` and `isHolding()` @cybex-dev
+* Refactor: Hold call signature changed to `holdCall({bool shouldHold = true})` @cybex-dev
 
 ## 0.0.9
 * Feat: forwarded callInvite custom parameters to flutter

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -422,7 +422,8 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             result.success(this.activeCall != null);
         } else if (call.method.equals("holdCall")) {
             Log.d(TAG, "Hold call invoked");
-            this.hold();
+            boolean shouldHold = call.argument("shouldHold");
+            this.updateHoldState(shouldHold);
             result.success(true);
         } else if (call.method.equals("isHolding")) {
             Log.d(TAG, "isHolding call invoked");
@@ -696,11 +697,17 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
 
     }
 
-    private void hold() {
+    private void updateHoldState(boolean shouldHold) {
         if (activeCall != null) {
             boolean hold = activeCall.isOnHold();
-            activeCall.hold(!hold);
-            sendPhoneCallEvents(hold ? "Unhold" : "Hold");
+            if (shouldHold && !hold) {
+                activeCall.hold(true);
+                sendPhoneCallEvents("Hold");
+            } else if(!shouldHold && hold) {
+                // hold call only when required to
+                activeCall.hold(false);
+                sendPhoneCallEvents("Unhold");
+            }
         }
     }
 

--- a/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
+++ b/android/src/main/java/com/twilio/twilio_voice/TwilioVoicePlugin.java
@@ -400,11 +400,21 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             sendPhoneCallEvents(speakerIsOn ? "Speaker On" : "Speaker Off");
 
             result.success(true);
+        } else if (call.method.equals("isOnSpeaker")) {
+            boolean isSpeakerOn = audioManager.isSpeakerphoneOn();
+            result.success(isSpeakerOn);
         } else if (call.method.equals("toggleMute")) {
           boolean muted = call.argument("muted");
             Log.d(TAG, "Muting call");
             this.mute(muted);
             result.success(true);
+        } else if (call.method.equals("isMuted")) {
+            Log.d(TAG, "isMuted invoked");
+            if(activeCall != null) {
+                result.success(activeCall.isMuted());
+            } else {
+                result.success(false);
+            }
         } else if (call.method.equals("call-sid")) {
             result.success(activeCall == null ? null : activeCall.getSid());
         } else if (call.method.equals("isOnCall")) {
@@ -414,6 +424,13 @@ public class TwilioVoicePlugin implements FlutterPlugin, MethodChannel.MethodCal
             Log.d(TAG, "Hold call invoked");
             this.hold();
             result.success(true);
+        } else if (call.method.equals("isHolding")) {
+            Log.d(TAG, "isHolding call invoked");
+            if(activeCall != null) {
+                result.success(activeCall.isOnHold());
+            } else {
+                result.success(false);
+            }
         } else if (call.method.equals("answer")) {
             Log.d(TAG, "Answering call");
             this.answer();

--- a/example/lib/call_screen.dart
+++ b/example/lib/call_screen.dart
@@ -11,6 +11,7 @@ class CallScreen extends StatefulWidget {
 class _CallScreenState extends State<CallScreen> {
   var speaker = false;
   var mute = false;
+  var isHolding = false;
   var isEnded = false;
 
   String? message = "Connecting...";
@@ -105,6 +106,37 @@ class _CallScreenState extends State<CallScreen> {
     listenCall();
     super.initState();
     caller = getCaller();
+    _loadCallState();
+  }
+
+  Future<void> _loadCallState() async {
+    await Future.wait([
+      _updateMuteState(),
+      _updateSpeakerState(),
+      _updateHoldState(),
+    ]);
+  }
+
+  Future<void> _updateMuteState() async {
+    final isMuted = await TwilioVoice.instance.call.isMuted();
+    setState(() {
+      mute = isMuted ?? false;
+    });
+  }
+
+  Future<void> _updateSpeakerState() async {
+    TwilioVoice.instance.call.isOnSpeaker().then((value) {
+      setState(() {
+        speaker = value ?? false;
+      });
+    });
+  }
+
+  Future<void> _updateHoldState() async {
+    final isHolding = await TwilioVoice.instance.call.isHolding();
+    setState(() {
+      this.isHolding = isHolding ?? false;
+    });
   }
 
   @override
@@ -177,7 +209,9 @@ class _CallScreenState extends State<CallScreen> {
                                 //   speaker = !speaker;
                                 // });
                                 TwilioVoice.instance.call
-                                    .toggleSpeaker(!speaker);
+                                    .toggleSpeaker(!speaker).then((value) {
+                                  _updateSpeakerState();
+                                });
                               },
                             ),
                           ),
@@ -208,7 +242,9 @@ class _CallScreenState extends State<CallScreen> {
                               ),
                               onTap: () {
                                 print("mute!");
-                                TwilioVoice.instance.call.toggleMute(!mute);
+                                TwilioVoice.instance.call.toggleMute(!mute).then((value) {
+                                  _updateMuteState();
+                                });
                                 // setState(() {
                                 //   mute = !mute;
                                 // });
@@ -217,6 +253,37 @@ class _CallScreenState extends State<CallScreen> {
                           ),
                         )
                       ]),
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      backgroundColor: isHolding ? Theme.of(context).primaryColor : Colors.white24,
+                      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24), side: BorderSide(color: Colors.white)),
+                    ),
+                    onPressed: () {
+                      print("Holding call? $isHolding");
+                      TwilioVoice.instance.call.holdCall(shouldHold: !isHolding).then((value) {
+                        _updateHoldState();
+                      });
+                    },
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (isHolding)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 4),
+                            child: Icon(
+                              Icons.pause,
+                              color: Colors.white,
+                            ),
+                          ),
+                        Text(
+                          isHolding ? "Call on hold" : "Hold call",
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
+                  ),
                   RawMaterialButton(
                     elevation: 2.0,
                     fillColor: Colors.red,

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -190,14 +190,23 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
          self.identity = clientIdentity;
          } */
         else if flutterCall.method == "holdCall" {
+            guard let shouldHold = arguments["shouldHold"] as? Bool else {return}
+            
             if (self.call != nil) {
-                
                 let hold = self.call!.isOnHold
-                self.call!.isOnHold = !hold
-                guard let eventSink = eventSink else {
-                    return
+                if(shouldHold && !hold) {
+                    self.call!.isOnHold = true
+                    guard let eventSink = eventSink else {
+                        return
+                    }
+                    eventSink("Hold")
+                } else if(!shouldHold && hold) {
+                    self.call!.isOnHold = false
+                    guard let eventSink = eventSink else {
+                        return
+                    }
+                    eventSink("Unhold")
                 }
-                eventSink(!hold ? "Hold" : "Unhold")
             }
         }
         else if flutterCall.method == "isHolding" {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -145,6 +145,14 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 _result!(ferror)
             }
         }
+        else if flutterCall.method == "isMuted"
+        {
+            if(self.call != nil) {
+                result(self.call!.isMuted);
+            } else {
+                result(false);
+            }
+        }
         else if flutterCall.method == "toggleSpeaker"
         {
             guard let speakerIsOn = arguments["speakerIsOn"] as? Bool else {return}
@@ -153,6 +161,11 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 return
             }
             eventSink(speakerIsOn ? "Speaker On" : "Speaker Off")
+        }
+        else if flutterCall.method == "isOnSpeaker"
+        {
+            let isOnSpeaker: Bool = isSpeakerOn();
+            result(isOnSpeaker);
         }
         else if flutterCall.method == "call-sid"
         {
@@ -186,6 +199,22 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 }
                 eventSink(!hold ? "Hold" : "Unhold")
             }
+        }
+        else if flutterCall.method == "isHolding" {
+            // guard call not nil
+            guard let call = self.call else {
+                return;
+            }
+            
+            // toggle state current state
+            let isOnHold = call.isOnHold;
+            call.isOnHold = !isOnHold;
+            
+            // guard event sink not nil & post update
+            guard let eventSink = eventSink else {
+                return
+            }
+            eventSink(!isOnHold ? "Hold" : "Unhold")
         }
         else if flutterCall.method == "answer" {
             // nuthin
@@ -619,6 +648,20 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.callOutgoing = false
         self.userInitiatedDisconnect = false
         
+    }
+    
+    func isSpeakerOn() -> Bool {
+        // Source: https://stackoverflow.com/a/51759708/4628115
+        let currentRoute = AVAudioSession.sharedInstance().currentRoute
+        for output in currentRoute.outputs {
+            switch output.portType {
+                case AVAudioSession.Port.builtInSpeaker:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        return false;
     }
     
     

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -270,9 +270,9 @@ class Call {
     return _channel.invokeMethod('answer', <String, dynamic>{});
   }
 
-  /// Holds active call
-  Future<bool?> holdCall() {
-    return _channel.invokeMethod('holdCall', <String, dynamic>{});
+  /// Sets hold call state using `shouldHold` value, returns true if successful
+  Future<bool?> holdCall({bool shouldHold = true}) {
+    return _channel.invokeMethod('holdCall', <String, dynamic>{"shouldHold": shouldHold});
   }
 
   /// Query's active call holding state

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -275,16 +275,31 @@ class Call {
     return _channel.invokeMethod('holdCall', <String, dynamic>{});
   }
 
-  /// Toogles mute state to provided value
+  /// Query's active call holding state
+  Future<bool?> isHolding() {
+    return _channel.invokeMethod('isHolding', <String, dynamic>{});
+  }
+
+  /// Toggles mute state to provided value
   Future<bool?> toggleMute(bool isMuted) {
     return _channel
         .invokeMethod('toggleMute', <String, dynamic>{"muted": isMuted});
   }
 
-  /// Toogles speaker state to provided value
+  /// Query's mute status of call, true if call is muted
+  Future<bool?> isMuted() {
+    return _channel.invokeMethod('isMuted', <String, dynamic>{});
+  }
+
+  /// Toggles speaker state to provided value
   Future<bool?> toggleSpeaker(bool speakerIsOn) {
     return _channel.invokeMethod(
         'toggleSpeaker', <String, dynamic>{"speakerIsOn": speakerIsOn});
+  }
+
+  /// Query's speaker output status, true if on loud speaker.
+  Future<bool?> isOnSpeaker() {
+    return _channel.invokeMethod('isOnSpeaker', <String, dynamic>{});
   }
 
   Future<bool?> sendDigits(String digits) {


### PR DESCRIPTION
This allows querying the active call for current `isHolding`, `isMuted` and `isOnSpeaker` states rather than relying on an internally stored state.

Further, `holdCall` signature change to pass a parameter i.e. `holdCall({bool = true})`