### PR TITLE
Fix: show incoming call screen with 'Pending' status

### DIFF
--- a/lib/_internal/js/call/call_status.dart
+++ b/lib/_internal/js/call/call_status.dart
@@ -7,21 +7,26 @@ enum CallStatus {
 
   // The media session associated with the call has been established - this depends on 'answerOnBridge' being set to true.
   // If not set to true, the call will be considered 'open' (or connected) once the call is connected to to Twilio.
+  open,
+  // (unofficial) synonymous with `open`
   connected,
 
   // The ICE connection was disconnected and a reconnection has been triggered.
   reconnecting,
 
-  // The ICE connection was disconnected, and has successfully reconnected.
+  // (unofficial) The ICE connection was disconnected, and has successfully reconnected.
   reconnected,
 
   // The callee has been notified of the call but has not yet responded.
   ringing,
 
-  // The recipient has rejected the incoming call.
+  // The call is incoming and hasn't yet been accepted.
+  pending,
+
+  //(unofficial) The recipient has rejected the incoming call.
   rejected,
 
-  // The recipient has answered the incoming call.
+  // (unofficial) The recipient has answered the incoming call.
   answer,
 }
 
@@ -32,6 +37,7 @@ CallStatus parseCallStatus(String status) {
     case "connecting":
       return CallStatus.connecting;
     case "open":
+      return CallStatus.open;
     case "connected":
       return CallStatus.connected;
     case "reconnecting":
@@ -39,8 +45,9 @@ CallStatus parseCallStatus(String status) {
     case "reconnected":
       return CallStatus.reconnected;
     case "ringing":
-    case "pending":
       return CallStatus.ringing;
+    case "pending":
+      return CallStatus.pending;
     case "rejected":
       return CallStatus.rejected;
     case "answer":

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -808,7 +808,7 @@ class Call extends MethodChannelTwilioCall {
   void _onCallStatusChanged(String status) {
     CallStatus callStatus = parseCallStatus(status);
 
-    if (callStatus == CallStatus.ringing) {
+    if (callStatus == CallStatus.pending) {
       /// jsCall should not be null here since `CallStatus.incoming` (incoming) or
       /// `CallStatus.connecting` (outgoing) via `place()` has already been fired and set
       _onCallRinging();

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -808,35 +808,14 @@ class Call extends MethodChannelTwilioCall {
   void _onCallStatusChanged(String status) {
     CallStatus callStatus = parseCallStatus(status);
 
-    switch (callStatus) {
-      case CallStatus.closed:
-        // TODO: Handle this case.
-        break;
-      case CallStatus.connected:
-        if (_jsCall != null) {
-          _onCallConnected(_jsCall!);
-        }
-        break;
-      case CallStatus.reconnecting:
-        // TODO: Handle this case.
-        break;
-      case CallStatus.reconnected:
-        // TODO: Handle this case.
-        break;
-      case CallStatus.connecting:
-      // Added missing Ringing for outgoing calls
-      case CallStatus.ringing:
-
-        /// jsCall should not be null here since `CallStatus.incoming` (incoming) or
-        /// `CallStatus.connecting` (outgoing) via `place()` has already been fired and set
-        _onCallRinging();
-        break;
-      case CallStatus.rejected:
-        // TODO: Handle this case.
-        break;
-      case CallStatus.answer:
-        // TODO: Handle this case.
-        break;
+    if (callStatus == CallStatus.ringing) {
+      /// jsCall should not be null here since `CallStatus.incoming` (incoming) or
+      /// `CallStatus.connecting` (outgoing) via `place()` has already been fired and set
+      _onCallRinging();
+    } else if (callStatus == CallStatus.connected) {
+      if (_jsCall != null) {
+        _onCallConnected(_jsCall!);
+      }
     }
   }
 


### PR DESCRIPTION
#### Changes:
- [web] Update `CallStatus` events
- [web] Code refactor
- [web] Trigger `onRinging` when `CallStatus.pending` is received (`ringing` is used by caller's side, `pending` is on recipient's side) `onRinging` is to inform the recipient of a new incoming call.