### PR TITLE
Fix web service worker race condition (on hold, see details)

### DIFF
--- a/lib/_internal/notifications_api/notification_options.dart
+++ b/lib/_internal/notifications_api/notification_options.dart
@@ -1,0 +1,15 @@
+/// Options for a notification.
+class NotificationOptions {
+  final String tag;
+  final String body;
+
+  NotificationOptions({required this.tag, required this.body});
+
+  /// Converts this object to a map.
+  Map<String, dynamic> toMap() {
+    return {
+      'tag': tag,
+      'body': body,
+    };
+  }
+}

--- a/lib/_internal/notifications_api/notifications_js.dart
+++ b/lib/_internal/notifications_api/notifications_js.dart
@@ -1,0 +1,17 @@
+import 'dart:html' as html;
+import 'notification_options.dart';
+
+/// Provides access to the browser's Service Worker implementation for the notification API.
+abstract class NotificationsJS {
+  /// Checks if the browser has notification permissions. True if the browser has notification permissions.
+  bool hasNotificationPermissions();
+
+  /// Shows a notification with the provided title and options.
+  void showNotification(String title, NotificationOptions options);
+
+  /// Gets a notification by tag. Returns a notification if found, null otherwise.
+  Future<html.Notification?> getNotificationByTag(String tag);
+
+  /// Cancels a notification by tag.
+  void cancelNotification(String tag);
+}

--- a/lib/_internal/notifications_api/notifications_js_impl.dart
+++ b/lib/_internal/notifications_api/notifications_js_impl.dart
@@ -1,0 +1,62 @@
+import 'dart:html' as html;
+
+import '../service_worker/twilio_sw.dart';
+import 'notification_options.dart';
+import 'notifications_js.dart';
+
+class NotificationsJSImpl extends ServiceWorkerJS implements NotificationsJS {
+
+  @override
+  void cancelNotification(String? tag) async {
+    if (tag == null || tag.isEmpty) {
+      console.error('Cannot cancel a notification with an null/empty tag');
+      return;
+    }
+
+    console.log("Canceling notification: $tag");
+    final notification = await getNotificationByTag(tag);
+    if (notification != null) {
+      notification.close();
+      console.log("Notification cancelled: $tag");
+    }
+  }
+
+  @override
+  Future<html.Notification?> getNotificationByTag(String tag) async {
+    assert(self != null, 'No service worker in control of page, did you forget register one?');
+
+    if (tag.isEmpty) {
+      console.error('Cannot get a notification with an null/empty tag');
+      return null;
+    }
+
+    final filter = {'tag': tag};
+    final notifications = await self!.getNotifications(filter);
+    if (notifications.length > 1) {
+      console.warn('Found more than one notification with tag: $tag');
+    }
+    return notifications.firstWhere((element) => element.tag == tag, orElse: () => null);
+  }
+
+  @override
+  bool hasNotificationPermissions() {
+    return html.Notification.permission == 'granted';
+  }
+
+  @override
+  void showNotification(String title, NotificationOptions options) async {
+    assert(self != null, 'No service worker in control of page, did you forget register one?');
+    assert(title.isNotEmpty, 'Notification title cannot be empty');
+    assert(options.tag.isNotEmpty, 'Notification options tag cannot be empty');
+
+    if (!hasNotificationPermissions()) {
+      console.warn('Cannot show notification without permissions');
+      return;
+    }
+
+    // TODO(cybex-dev): Check for existing notification with the same tag and close it if it exists
+    self!.showNotification(title, options.toMap()).catchError((error) {
+      console.error('Failed to show notification: $title, $options, $error');
+    });
+  }
+}

--- a/lib/_internal/service_worker/event_message.dart
+++ b/lib/_internal/service_worker/event_message.dart
@@ -1,0 +1,6 @@
+class EventMessage {
+  final String action;
+  final Map<String, dynamic> payload;
+
+  EventMessage(this.action, this.payload);
+}

--- a/lib/_internal/service_worker/logger.dart
+++ b/lib/_internal/service_worker/logger.dart
@@ -1,0 +1,26 @@
+import 'dart:html' as html;
+
+abstract class ConsoleLogger {
+  /// Gets the console object.
+  html.Console get console => html.window.console;
+
+  /// Logs a message to the console.
+  void log(String message, {String? tag}) {
+    console.log("[$tag] $message");
+  }
+
+  /// Logs a message to the console.
+  void warn(String message, {String? tag}) {
+    console.warn("[$tag] $message");
+  }
+
+  /// Logs a message to the console.
+  void error(String message, {String? tag}) {
+    console.error("[$tag] $message");
+  }
+
+  /// Logs a message to the console.
+  void debug(String message, {String? tag}) {
+    console.debug("[$tag] $message");
+  }
+}

--- a/lib/_internal/service_worker/twilio_sw.dart
+++ b/lib/_internal/service_worker/twilio_sw.dart
@@ -1,0 +1,24 @@
+import 'dart:html' as html;
+
+import 'logger.dart';
+import 'event_message.dart';
+
+/// Provides access to the browser's Service Worker implementation. Allows getting the current service worker, container and registration via [self]. Allows interacting with the [self] service worker.
+/// https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
+abstract class ServiceWorkerJS extends ConsoleLogger {
+  html.ServiceWorker? get serviceWorker => serviceWorkerContainer?.controller;
+
+  html.ServiceWorkerContainer? get serviceWorkerContainer => html.window.navigator.serviceWorker;
+
+  /// Gets the service worker registration object, emulates the JS function
+  /// `navigator.serviceWorker.ready`
+  Future<html.ServiceWorkerRegistration>? get registrationReady => html.window.navigator.serviceWorker?.ready;
+
+  static html.ServiceWorkerRegistration? _registration;
+
+  html.ServiceWorkerRegistration? get self => _registration;
+
+  set registration(html.ServiceWorkerRegistration? value) {
+    registration = value;
+  }
+}

--- a/lib/_internal/service_worker/twilio_sw_imp.dart
+++ b/lib/_internal/service_worker/twilio_sw_imp.dart
@@ -1,0 +1,34 @@
+import 'package:twilio_voice/_internal/service_worker/twilio_sw.dart';
+
+/// Provides access to the browser's Service Worker implementation. Allows getting the current service worker, container and registration via [self]. Allows interacting with the [self] service worker.
+/// https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
+class ServiceWorkerJSImpl extends ServiceWorkerJS {
+  ServiceWorkerJSImpl() {
+    registerSelf();
+    _attachEventListeners();
+  }
+
+  void registerSelf() {
+    // TODO
+    serviceWorkerContainer?.register('twilio_service_worker.js').then((registration) {
+      registration = registration;
+      console.log('Twilio Voice Service worker registered successfully');
+    }).catchError((error) {
+      console.warn('Error registering Twilio Service Worker: $error. This prevents notifications from working natively');
+    });
+  }
+
+  void _attachEventListeners() {
+    serviceWorkerContainer?.addEventListener('message', (event) {
+      console.log('Received message from service worker: $event');
+      // final message = EventMessage.fromEvent(event);
+      // if (message == null) {
+      //   return;
+      // }
+      // console.log('Received message from service worker: $message');
+      // if (message.type == 'registration') {
+      //   _registration = message.data as html.ServiceWorkerRegistration?;
+      // }
+    });
+  }
+}

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -23,14 +23,14 @@ import 'local_storage_web/local_storage_web.dart';
 import 'method_channel/twilio_call_method_channel.dart';
 import 'method_channel/twilio_voice_method_channel.dart';
 
-class TwilioSW {
-  TwilioSW._() {
+class TwilioSWInterface {
+  TwilioSWInterface._() {
     _setupServiceWorker();
   }
 
-  static TwilioSW _instance = TwilioSW._();
+  static final TwilioSWInterface _instance = TwilioSWInterface._();
 
-  static TwilioSW get instance => _instance;
+  static TwilioSWInterface get instance => _instance;
 
   html.ServiceWorkerContainer? _webServiceWorkerContainerDelegate;
   html.ServiceWorker? _webServiceWorkerDelegate;
@@ -91,7 +91,7 @@ class TwilioSW {
 }
 
 class NotificationService {
-  TwilioSW _twilioSW = TwilioSW.instance;
+  TwilioSWInterface _twilioSW = TwilioSWInterface.instance;
 
   NotificationService._();
 
@@ -216,7 +216,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     // loadTwilio();
 
     // setup SW listener
-    final sw = TwilioSW.instance;
+    final sw = TwilioSWInterface.instance;
     sw._setupServiceWorker();
     sw.onMessageReceived = _handleServiceWorkerMessage;
   }
@@ -402,7 +402,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     try {
       device?.unregister();
       _detachDeviceListeners(device!);
-      TwilioSW.instance.destroy();
+      TwilioSWInterface.instance.destroy();
       return true;
     } catch (e) {
       print("Failed to unregister device: $e");
@@ -982,7 +982,7 @@ class Call extends MethodChannelTwilioCall {
         'tag': callSid,
       },
     };
-    TwilioSW.instance.send(message);
+    TwilioSWInterface.instance.send(message);
   }
 }
 


### PR DESCRIPTION
Flutter Web uses `flutter_service_worker.js`, however adding a custom service worker e.g. `twilio_sw.js` causes the first to load (first being which ever is first declared as a `<script/>`)

Flutter is addressing the issue of custom service workers:
https://github.com/flutter/flutter/issues/67625
