### PR TITLE
Fix: Web notifications stop showing on page (soft) refreshing

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -45,17 +45,8 @@
   <!--twilio native js library-->
   <script type="text/javascript" src="./notifications.js"></script>
 
-  <script>
-    if ('serviceWorker' in navigator) {
-        window.addEventListener('load', async () => {
-            await navigator.serviceWorker.register('./twilio-sw.js').then(value => {
-                console.log('Twilio Voice Service worker registered successfully.');
-            }).catch((error) => {
-                console.warn('Error registering Twilio Service Worker: ' + error.message + '. This prevents notifications from working natively');
-            });
-        });
-    }
-  </script>
+  <script type="text/javascript" src="./load-sw.js"></script>
+
   <script>
     window.addEventListener('load', function(ev) {
       // Download main.dart.js

--- a/example/web/load-sw.js
+++ b/example/web/load-sw.js
@@ -1,5 +1,14 @@
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', async () => {
+        // https://github.com/mswjs/msw/issues/98
+        if(!navigator.serviceWorker.controller) {
+            console.warn('No service worker controller found. This page is not loaded in a service worker context. Will attempt to unregister all service workers and re-register.');
+            const registrations = await navigator.serviceWorker.getRegistrations()
+            if(registrations.length > 0) {
+                console.warn('No service worker controller found, but multiple services worker registrations are present. Unregistering...');
+                await Promise.all(registrations.map(r => r.unregister()))
+            }
+        }
         await navigator.serviceWorker.register('./twilio-sw.js').then(value => {
             console.log('Twilio Voice Service worker registered successfully.');
         }).catch((error) => {

--- a/example/web/load-sw.js
+++ b/example/web/load-sw.js
@@ -1,0 +1,9 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+        await navigator.serviceWorker.register('./twilio-sw.js').then(value => {
+            console.log('Twilio Voice Service worker registered successfully.');
+        }).catch((error) => {
+            console.warn('Error registering Twilio Service Worker: ' + error.message + '. This prevents notifications from working natively');
+        });
+    });
+}

--- a/example/web/twilio-sw.js
+++ b/example/web/twilio-sw.js
@@ -32,9 +32,9 @@ self.addEventListener('activate', (event) => {
 });
 
 // disabled due to Chrome no-op warning
-self.addEventListener('fetch', (event) => {
-   _log(`fetch event [${event.request.url}]`, event);
-});
+//self.addEventListener('fetch', (event) => {
+//   _log(`fetch event [${event.request.url}]`, event);
+//});
 
 self.addEventListener('install', (event) => {
     _log('install event, skip waiting', event);


### PR DESCRIPTION
Upon a page refresh (soft) via direct or indirect, notifications will stop working due to the page controller being reassigned (i.e. null).

A solution provided [https://github.com/mswjs/msw/issues/98#issuecomment-612118211](https://github.com/mswjs/msw/issues/98#issuecomment-612118211) suggests unregistering all registrations, then attempting to re-register.

This may however have adverse effects on the existing `flutter_service_worker.js`.

In future, a better solution may be to incorporate the custom service worker code into the predefined and 'hardcoded' `flutter_service_worker.js` file (generated on `flutter build web`) via a `Makefile`  script as suggested [here](https://github.com/flutter/flutter/issues/67625#issuecomment-868701035) via github actions and/or with an Makefile example [here](https://stackoverflow.com/a/68766154/4628115)