### PR TITLE
Fix background calls rejecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # twilio_voice
 
 Provides an interface to Twilio's Programmable Voice SDK to allow voice-over-IP (VoIP) calling into
@@ -6,9 +5,11 @@ your Flutter applications.
 ~~This plugin was taken from the original `flutter_twilio_voice` as it seems that plugin is no longer maintained, this one is.~~  Project ownership & maintenance handed over by [diegogarcia](https://github.com/diegogarciar). For the foreseeable future, I'll be actively maintaining this project.
 
 #### 🐞Bug? Issue? Something odd?
+
 Report it [here](https://github.com/cybex-dev/twilio_voice/issues/new?assignees=&labels=type:Bug,status:Unconfirmed&projects=&template=BUG_REPORT.md&title=).
 
 #### 🚀 Feature Requests?
+
 Any and all [Feature Requests](https://github.com/cybex-dev/twilio_voice/issues/new?assignees=&labels=type:Enhancement&projects=&template=FEATURE_REQUEST.md&title=) or Pull Requests are gladly welcome!
 
 #### Live Example/Samples:
@@ -24,9 +25,10 @@ Any and all [Feature Requests](https://github.com/cybex-dev/twilio_voice/issues/
 - Receive and place calls from Web (FCM push notification integration not yet supported by Twilio Voice Web, see [here](https://github.com/twilio/twilio-voice.js/pull/159#issuecomment-1551553299) for discussion)
 - Receive and place calls from MacOS devices, uses custom UI to receive calls (in future & macOS
   13.0+, we'll be using CallKit).
--  Interpret TwiML parameters to populate UI, see below [Interpreting Parameters](#interpreting-parameters)
+- Interpret TwiML parameters to populate UI, see below [Interpreting Parameters](#interpreting-parameters)
 
 ## Feature addition schedule:
+
 - Audio device selection support (select input/output audio devices, on-hold)
 - Update plugin to Flutter federated packages (step 1 of 2 with Web support merge)
 - Desktop platform support (implementation as JS wrapper/native implementation, Windows/Linux to start development)
@@ -76,7 +78,7 @@ see [[Limitations]](https://github.com/diegogarciar/twilio_voice/blob/master/NOT
 register in your `AndroidManifest.xml` the service in charge of displaying incoming call
 notifications:
 
-``` xml
+```xml
 <Application>
  .....
  <service
@@ -89,29 +91,37 @@ notifications:
 #### Phone Account
 
 To register a Phone Account, request access to `READ_PHONE_NUMBERS` permission first:
+
 ```dart
 TwilioVoice.instance.requestReadPhoneNumbersPermission();  // Gives Android permissions to read Phone Accounts
 ```
+
 then, register the `PhoneAccount` with:
+
 ```dart
 TwilioVoice.instance.registerPhoneAccount();
 ```
 
 #### Enable calling account
+
 To open the `Call Account` settings, use the following code:
+
 ```dart
 TwilioVoice.instance.openPhoneAccountSettings();
 ```
 
 Check if it's enabled with:
+
 ```dart
 TwilioVoice.instance.isPhoneAccountEnabled();
 ```
 
 #### Calling with ConnectionService
+
 Placing a call with Telecom app via Connection Service requires a `PhoneAccount` to be registered. See [Phone Account](#phone-account) above for more information.
 
 Finally, to grant access to place calls, run:
+
 ```dart
 TwilioVoice.instance.requestCallPhonePermission();  // Gives Android permissions to place calls
 ```
@@ -119,7 +129,9 @@ TwilioVoice.instance.requestCallPhonePermission();  // Gives Android permissions
 See [Customizing the Calling Account](#customizing-the-calling-account) for more information.
 
 #### Enabling the ConnectionService
+
 To enable the `ConnectionService` and make/receive calls, run:
+
 ```dart
 TwilioVoice.instance.requestReadPhoneStatePermission();  // Gives Android permissions to read Phone State
 ```
@@ -127,14 +139,17 @@ TwilioVoice.instance.requestReadPhoneStatePermission();  // Gives Android permis
 Highly recommended to review the notes for **Android**. See [[Notes]](https://github.com/diegogarciar/twilio_voice/blob/master/NOTES.md#android) for more information.
 
 #### Customizing the Calling Account
+
 To customize the `label` and `shortDescription` of the calling account, add the following in your `res/values/strings.xml`:
+
 ```xml
 <string name="phone_account_name" translatable="false">Example App</string>
 <string name="phone_account_desc" translatable="false">Example app voice calls calling account</string>
 ```
+
 This can be found in alternatively the Phone App's settings, `Other/Advanced Call Settings -> Calling Accounts -> (Example App)` (then toggle the switch)
 
-![enter image description here](https://i.imgur.com/SwtZjgD.png)
+![enter image description here](https://i.imgur.com/6mhjFWZ.gif)
 
 See [example](https://github.com/cybex-dev/twilio_voice/blob/master/example/android/app/src/main/res/values/strings.xml) for more details
 
@@ -149,19 +164,21 @@ See [example](https://github.com/cybex-dev/twilio_voice/blob/master/example/andr
 ### Web Setup:
 
 There are 2 important files for Twilio incoming/missed call notifications to work:
+
 - `notifications.js` is the main file, it handles the notifications and the service worker.
 - `twilio-sw.js` is the service worker, it is used to handle the incoming calls.
 
 Also, the twilio javascript SDK itself, `twilio.min.js` is needed.
 
 To ensure proper/as intended setup:
+
 1. Get all 3 files (`notifications.js`, `twilio.min.js` and `twilio-sw.js`) from `example/web` folder
 2. Copy all 3 into your own project,
 3. (optional) Review & change the `notifications.js`, `twilio-sw.js) files to match your needs.
 
 Finally, add the following code to your `index.html` file, **at the end of body tag**:
 
-``` html
+```html
     <body>
         <!--twilio native js library-->
         <script type="text/javascript" src="./twilio.min.js"></script>
@@ -183,6 +200,7 @@ Finally, add the following code to your `index.html` file, **at the end of body 
 ```
 
 #### Web Considerations
+
 Notice should be given to using `firebase-messaging-sw.js` in addition to `twilio-sw.js` since these may cause conflict in service worker events being handled.
 
 _If you need to debug the service worker, open up Chrome Devtools, go to Application tab, and select Service Workers from the left menu. There you can see the service workers and their status.
@@ -196,20 +214,21 @@ wrapper. This makes macOS integration a drop-in solution.
 However, you'll need to:
 
 1. add the following to your `Info.plist` file:
-    ``` xml
-    <key>NSMicrophoneUsageDescription</key>
-    <string>Allow microphone access to make calls</string>
-    ```
+
+   ```xml
+   <key>NSMicrophoneUsageDescription</key>
+   <string>Allow microphone access to make calls</string>
+   ```
 2. include Hardened Runtime entitlements (this is required for App Store distributed MacOS apps):
-    ``` xml
+
+   ```xml
    <key>com.apple.security.audio-input</key>
    <true/>
 
-    <!--Optionally for bluetooth support/permissions-->
+   <!--Optionally for bluetooth support/permissions-->
    <key>com.apple.security.device.bluetooth</key>
    <true/>
-    ```
-
+   ```
 3. Lastly and most importantly, ensure the `index.html` and `twilio.min.js` is bundled inside of `twilio_voice` package (this
    shouldn't be a problem, but just in case). Found in `twilio_voice.../.../Classes/Resources/*`.
 
@@ -297,37 +316,39 @@ The events sent are the following
 
 As a convenience, the plugin will interpret the TwiML parameters and send them as a map in the `CallInvite` or provided via `extraOptions` when creating the call. This is useful for passing additional information to the call screen and are prefixed with `__TWI`.
 
- - `__TWI_CALLER_ID` - caller id
- - `__TWI_CALLER_NAME` - caller name
- - `__TWI_CALLER_URL` - caller image/thumbnail url (not implemented/supported at the moment)
- - `__TWI_RECIPIENT_ID` - recipient id
- - `__TWI_RECIPIENT_NAME` - recipient name
- - `__TWI_RECIPIENT_URL` - recipient image/thumbnail url (not implemented/supported at the moment)
- - `__TWI_SUBJECT` - subject/additional info
+- `__TWI_CALLER_ID` - caller id
+- `__TWI_CALLER_NAME` - caller name
+- `__TWI_CALLER_URL` - caller image/thumbnail url (not implemented/supported at the moment)
+- `__TWI_RECIPIENT_ID` - recipient id
+- `__TWI_RECIPIENT_NAME` - recipient name
+- `__TWI_RECIPIENT_URL` - recipient image/thumbnail url (not implemented/supported at the moment)
+- `__TWI_SUBJECT` - subject/additional info
 
- These parameters above are interpreted as follows.
+These parameters above are interpreted as follows.
 
- #### Name resolution
- Caller is usually referred to as `call.from` or `callInvite.from`. This can either be a number of a string (with the format `client:clientName`) or null.
+#### Name resolution
 
- The following rules are applied to determine the caller/recipient name, which is shown in the call screen and heads-up notification:
+Caller is usually referred to as `call.from` or `callInvite.from`. This can either be a number of a string (with the format `client:clientName`) or null.
 
- - If the caller is empty/not provided, the default caller name is shown e.g. "Unknown Caller", else
- - if the caller is a number, the plugin will show the number as is, else
- - if the caller is a string, the plugin will interpret the string as follows:
-    - if the `__TWI_CALLER_NAME` parameter is provided, the plugin will show the value of `__TWI_CALLER_NAME` as is, else
-    - if the `__TWI_CALLER_ID` parameter is provided, the plugin will search for a registered client with the same id and show the client name, else
-    - if not found or not provided, the plugin will search for a registered client with the `call.from` value and show the client name, as a last resort
-    - the default caller name is shown e.g. "Unknown Caller"
+The following rules are applied to determine the caller/recipient name, which is shown in the call screen and heads-up notification:
+
+- If the caller is empty/not provided, the default caller name is shown e.g. "Unknown Caller", else
+- if the caller is a number, the plugin will show the number as is, else
+- if the caller is a string, the plugin will interpret the string as follows:
+  - if the `__TWI_CALLER_NAME` parameter is provided, the plugin will show the value of `__TWI_CALLER_NAME` as is, else
+  - if the `__TWI_CALLER_ID` parameter is provided, the plugin will search for a registered client with the same id and show the client name, else
+  - if not found or not provided, the plugin will search for a registered client with the `call.from` value and show the client name, as a last resort
+  - the default caller name is shown e.g. "Unknown Caller"
 
 *Please note: the same approach applies to both caller and recipient name resolution.*
 
- #### Subject
+#### Subject
 
- Using the provided `__TWI_SUBJECT` parameter, the plugin will show the subject as is, else (depending on the platform and manufacturer), the plugin will show:
-  - the caller name as the subject, or
-  - the app name as the subject, or
-  - the default subject "Incoming Call"
+Using the provided `__TWI_SUBJECT` parameter, the plugin will show the subject as is, else (depending on the platform and manufacturer), the plugin will show:
+
+- the caller name as the subject, or
+- the app name as the subject, or
+- the default subject "Incoming Call"
 
 ## showMissedCallNotifications
 
@@ -351,6 +372,7 @@ use `extraOptions` to pass additional variables to your server callback function
 These translate to the your TwiML `event` function/service as:
 
 *javascript sample*
+
 ```javascript
 exports.handler = function(context, event, callback) {
     const from = event.From;
@@ -364,6 +386,16 @@ exports.handler = function(context, event, callback) {
 See [Setting up the Application](#setting-up-the-application) for more information.
 
 *Please note: the hardcoded `To`, `From` may change in future.*
+
+#### Receiving Calls
+
+##### iOS
+
+Receives calls via [CallKit](https://developer.apple.com/documentation/callkit) integration. Make sure to review the [iOS Setup](#ios-setup) section for more information.
+
+##### Android
+
+Receives calls via [ConnectionService](https://developer.android.com/reference/android/telecom/ConnectionService) integration. Make sure to review the [Android Setup](#android-setup) section for more information.
 
 #### Mute a Call
 
@@ -414,6 +446,41 @@ page to enable the permission.~~
 
 Deprecated in 0.10.0, as it is no longer needed. Custom UI has been replaced with native UI.
 
+#### ConnectionService & Native Phone Account (Android only)
+
+Similar to CallKit on iOS, Android implements their own via a [ConnectionService](https://developer.android.com/reference/android/telecom/ConnectionService) integration. To make use of this, you'll need to request `CALL_PHONE` permissions via:
+
+```dart
+TwilioVoice.instance.requestCallPhonePermission();  // Gives Android permissions to place outgoing calls
+TwilioVoice.instance.requestReadPhoneStatePermission();  // Gives Android permissions to read Phone State including receiving calls
+TwilioVoice.instance.requestReadPhoneNumbersPermission();  // Gives Android permissions to read Phone Accounts
+```
+
+Following this, to register a Phone Account (required by all applications implementing a system-managed `ConnectionService`, run:
+
+```dart
+TwilioVoice.instance.registerPhoneAccount();  // Registers the Phone Account
+TwilioVoice.instance.openPhoneAccountSettings();  // Opens the Phone Account settings
+
+// After the account is enabled, you can check if it's enabled with:
+TwilioVoice.instance.isPhoneAccountEnabled();  // Checks if the Phone Account is enabled
+```
+
+This last step can be considered the 'final check' to make/receive calls on Android.
+
+**Permissions not granted?**
+
+Finally, a consideration for not all (`CALL_PHONE`) permissions granted on an Android device. The following feature is available on Android only:
+
+```dart
+TwilioVoice.instance.rejectCallOnNoPermissions({Bool = false}); // Rejects incoming calls if permissions are not granted
+TwilioVoice.instance.isRejectingCallOnNoPermissions(); // Checks if the plugin is rejecting calls if permissions are not granted
+```
+
+If the `CALL_PHONE` permissions group i.e. `READ_PHONE_STATE`, `READ_PHONE_NUMBERS`, `CALL_PHONE` aren't granted nor a Phone Account is registered and enabled, the plugin will either reject the incoming call (true) or not show the incoming call UI (false).
+
+See [Android Setup](#android-setup) and [Android Notes](https://github.com/diegogarciar/twilio_voice/blob/master/NOTES.md#android) for more information regarding configuring the `ConnectionService` and registering a Phone Account.
+
 ### Localization
 
 Because some of the UI is in native code, you need to localize those strings natively in your
@@ -450,7 +517,7 @@ the `make-call` function.
 This will allow you to actually place the call
 
 Prerequisites
----
+-------------
 
 * A Twilio Account. Don't have one? [Sign up](https://www.twilio.com/try-twilio) for free!
 
@@ -614,16 +681,15 @@ the deployment text. If this isn't done, calling won't work!
 
 Twilio's configurations are stored in `.runtimeconfig.json` which contains:
 
-    "auth_token": "",
-    "account_sid": "",
-    "app_sid": "",
-    "phone": "",
-    "api_key": "",
-    "api_key_secret": "",
-    "android_push_credential": "",
-    "apple_push_credential_debug": "",
-    "apple_push_credential_release": ""
-
+"auth_token": "",
+"account_sid": "",
+"app_sid": "",
+"phone": "",
+"api_key": "",
+"api_key_secret": "",
+"android_push_credential": "",
+"apple_push_credential_debug": "",
+"apple_push_credential_release": ""
 _**Note:** this is used for local emulator testing, but you need to deploy these to your firebase
 function application once you are ready to go live. If you don't, this won't work!_
 
@@ -646,7 +712,6 @@ twilio api:chat:v2:credentials:create \
 --friendly-name="voice-push-credential-fcm" \
 --secret=SERVER_KEY_VALUE
 ```
-
 and then place into the field: `android_push_credential` above
 
 This generated a push credential SID in the format `CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` which must
@@ -678,7 +743,6 @@ $ openssl pkcs12 -in PATH_TO_YOUR_SANDBOX_P12 -nokeys -out sandbox_cert.pem -nod
 $ openssl pkcs12 -in PATH_TO_YOUR_SANDBOX_P12 -nocerts -out sandbox_key.pem -nodes
 $ openssl rsa -in sandbox_key.pem -out sandbox_key.pem
 ```
-
 Using sandbox certificates, generate credential:
 
 ```
@@ -689,7 +753,6 @@ twilio api:chat:v2:credentials:create \
 --certificate="$(cat PATH_TO_SANDBOX_CERT_PEM)" \
 --private-key="$(cat PATH_TO_SANDBOX_KEY_PEM)"
 ```
-
 then place it into the field `apple_push_credential_debug`
 
 **- Production Mode**
@@ -704,7 +767,6 @@ $ openssl pkcs12 -in PATH_TO_YOUR_P12 -nokeys -out prod_cert.pem -nodes
 $ openssl pkcs12 -in PATH_TO_YOUR_P12 -nocerts -out prod_key.pem -nodes
 $ openssl rsa -in prod_key.pem -out prod_key.pem
 ```
-
 Using production certificates, generate credential:
 
 ```
@@ -714,7 +776,6 @@ twilio api:chat:v2:credentials:create \
 --certificate="$(cat PATH_TO_PROD_CERT_PEM)" \
 --private-key="$(cat PATH_TO_PROD_KEY_PEM)"
 ```
-
 then place it into the field `apple_push_credential_release`
 
 see for more
@@ -805,7 +866,6 @@ exports.accessToken = functions.https.onCall((payload, context) => {
     };
 });
 ```
-
 Add the function above to your Firebase Functions application,
 see [this](https://firebase.google.com/docs/functions/get-started) for more help on creating a
 firebase functions project
@@ -818,7 +878,6 @@ Once done with everything above, deploy your firebase function with this:
 ```bash
 firebase deploy --only functions
 ```
-
 ##### Done!
 
 Calling should work naturally - just make sure to fetch the token from the endpoint and you can call
@@ -827,10 +886,11 @@ See [example](https://github.com/diegogarciar/twilio_voice/blob/master/example/l
 code, make sure to change the `voice-accessToken` to your function name, given to you by firebase
 when deploying (as part of the deploy text)
 
-
 ## Future Work
+
 - Move package to `federated plugin` structure (see [here](https://flutter.dev/go/federated-plugins) for more info), see reduced overhead advantages covered as motivation (see [here](https://medium.com/flutter/how-to-write-a-flutter-web-plugin-part-2-afdddb69ece6) for more info))
 
 ## Updating Twilio Voice JS SDK
+
 `twilio.js` is no longer hosted via CDNs (see [reference](https://github.com/twilio/twilio-voice.js/blob/master/README.md#cdn)), instead it is hosted via npm / github. See instructions found [here](https://github.com/twilio/twilio-voice.js/blob/master/README.md#github)
 This is automatically added to your `web/index.html` file, as a `<script/>` tag during runtime. See [here](./lib/_internal/twilio_loader.dart) for more info.);

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -867,6 +867,41 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 result.success(true)
             }
 
+            TVMethodChannels.REJECT_CALL_ON_NO_PERMISSIONS -> {
+                val shouldRejectOnNoPermissions = call.argument<Boolean>("shouldReject") ?: run {
+                    result.error(
+                        FlutterErrorCodes.MALFORMED_ARGUMENTS,
+                        "No 'shouldReject' provided or invalid type",
+                        null
+                    )
+                    return@onMethodCall
+                }
+
+                storage?.let {
+                    logEvent("shouldRejectOnNoPermissions is $shouldRejectOnNoPermissions")
+                    it.rejectOnNoPermissions = shouldRejectOnNoPermissions
+                    result.success(true)
+                } ?: run {
+                    Log.e(
+                        TAG,
+                        "Storage is null, cannot set reject on no permissions. Has Storage been initialized?"
+                    )
+                    result.success(false)
+                }
+            }
+
+            TVMethodChannels.IS_REJECTING_CALL_ON_NO_PERMISSIONS -> {
+                storage?.let {
+                    result.success(it.rejectOnNoPermissions)
+                } ?: run {
+                    Log.e(
+                        TAG,
+                        "Storage is null, cannot set reject on no permissions. Has Storage been initialized?"
+                    )
+                    result.success(false)
+                }
+            }
+
             else -> {
                 result.notImplemented()
             }

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -694,7 +694,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 } ?: run {
                     Log.e(
                         TAG,
-                        "Storage is null, cannot unregister client. Has Storage been initialized?"
+                        "Storage is null, cannot set default caller. Has Storage been initialized?"
                     )
                     result.success(false)
                 }
@@ -846,7 +846,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 } ?: run {
                     Log.e(
                         TAG,
-                        "Storage is null, cannot unregister client. Has Storage been initialized?"
+                        "Storage is null, cannot set showNotifications. Has Storage been initialized?"
                     )
                     result.success(false)
                 }

--- a/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
@@ -49,10 +49,12 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
         }
 }
 
-class TVCallParametersImpl(storage: Storage, call: Call, customParameters: Map<String, String> = emptyMap()) : TVParametersImpl(storage) {
+class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFrom: String, customParameters: Map<String, String> = emptyMap()) : TVParametersImpl(storage) {
     private var mCallSid: String? = null
 
     private val mCall: Call
+    private val mFrom: String
+    private val mTo: String
     override var callSid: String
         get() = mCallSid ?: ""
         set(value) {
@@ -61,11 +63,12 @@ class TVCallParametersImpl(storage: Storage, call: Call, customParameters: Map<S
 
     init {
         mCall = call
+        mFrom = callFrom
+        mTo = callTo
     }
 
     override val from: String
         get() {
-            val mFrom = mCall.from ?: ""
             if (mFrom.isEmpty()) {
                 return mStorage.defaultCaller
             }
@@ -75,15 +78,14 @@ class TVCallParametersImpl(storage: Storage, call: Call, customParameters: Map<S
                 return mFrom
             }
 
-            val mToName = mFrom.replace("client:", "")
+            val mFromName = mFrom.replace("client:", "")
             return customParameters[PARAM_RECIPIENT_NAME]
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
-                ?: resolveHumanReadableName(mToName)
+                ?: resolveHumanReadableName(mFromName)
         }
 
     override val to: String
         get() {
-            val mTo = mCall.to ?: ""
             if (mTo.isEmpty()) {
                 return mStorage.defaultCaller
             }
@@ -100,10 +102,10 @@ class TVCallParametersImpl(storage: Storage, call: Call, customParameters: Map<S
         }
 
     override val fromRaw: String
-        get() = mCall.from ?: ""
+        get() = mFrom
 
     override val toRaw: String
-        get() = mCall.to ?: ""
+        get() = mTo
 }
 
 open class TVParametersImpl(storage: Storage, override val callSid: String = "", override val customParameters: Map<String, String> = emptyMap()) : TVParameters {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
@@ -102,10 +102,16 @@ class VoiceFirebaseMessagingService : FirebaseMessagingService(), MessageListene
             requiredPermissions += "No `READ_PHONE_NUMBERS` permission, cannot communicate with ConnectionService if not granted. Request this with `requestReadPhoneNumbersPermission()`"
         }
 
-        // Check permission RECORD_AUDIO
-        if (!applicationContext.hasMicrophoneAccess()) {
-            shouldRejectCall = true
-            requiredPermissions += "No `RECORD_AUDIO` permission, VoiceSDK requires this permission. Request this with `requestMicPermission()`"
+        // NOTE(cybex-dev): Foreground services requiring privacy permission e.g. microphone or
+        // camera are required to be started in the foreground. Since we're using the Telecom's
+        // PhoneAccount, we don't directly require microphone access. Further, microphone access
+        // is always denied if the app requiring microphone access via a Foreground service
+        // is in the background (by design).
+//        // Check permission RECORD_AUDIO
+//        if (!applicationContext.hasMicrophoneAccess()) {
+//            shouldRejectCall = true
+//            requiredPermissions += "No `RECORD_AUDIO` permission, VoiceSDK requires this permission. Request this with `requestMicPermission()`"
+//        }
         }
 
         if(!tm.hasCallCapableAccount(applicationContext, TVConnectionService::class.java.name)) {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
@@ -75,6 +75,15 @@ class VoiceFirebaseMessagingService : FirebaseMessagingService(), MessageListene
     @RequiresPermission(allOf = [Manifest.permission.RECORD_AUDIO, Manifest.permission.READ_PHONE_STATE, Manifest.permission.READ_PHONE_NUMBERS])
     @SuppressLint("MissingPermission")
     override fun onCallInvite(callInvite: CallInvite) {
+        Log.d(
+            TAG,
+            "onCallInvite: {\n\t" +
+                    "CallSid: ${callInvite.callSid}, \n\t" +
+                    "From: ${callInvite.from}, \n\t" +
+                    "To: ${callInvite.to}, \n\t" +
+                    "Parameters: ${callInvite.customParameters.entries.joinToString { "${it.key}:${it.value}" }},\n\t" +
+                    "}"
+        )
         // Get TelecomManager instance
         val tm = applicationContext.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
@@ -43,8 +43,7 @@ class TVCallInviteConnection(
 
     override fun onAnswer() {
         super.onAnswer()
-        val call = callInvite.accept(context, this)
-        setCall(call)
+        twilioCall = callInvite.accept(context, this)
         onAction?.onChange(TVNativeCallActions.ACTION_ANSWERED, Bundle().apply {
             putParcelable(TVBroadcastReceiver.EXTRA_CALL_INVITE, callInvite)
             putInt(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, callDirection.id)
@@ -79,7 +78,7 @@ open class TVCallConnection(
 
     open val TAG = "VoipConnection"
     val context: Context
-    private var twilioCall: Call? = null
+    var twilioCall: Call? = null
     var onDisconnected: CompletionHandler<DisconnectCause>? = null
     var onEvent: ValueBundleChanged<String>? = null
     var onAction: ValueBundleChanged<String>? = null
@@ -97,10 +96,6 @@ open class TVCallConnection(
 
     fun setOnCallDisconnected(handler: CompletionHandler<DisconnectCause>) {
         onDisconnected = handler
-    }
-
-    fun setCall(call: Call) {
-        twilioCall = call
     }
 
     fun setOnCallEventListener(listener: ValueBundleChanged<String>) {
@@ -165,8 +160,8 @@ open class TVCallConnection(
 
     override fun onConnected(call: Call) {
         Log.d(TAG, "onConnected: onConnected")
-        setActive()
         twilioCall = call
+        setActive()
         onEvent?.onChange(TVNativeCallEvents.EVENT_CONNECTED, Bundle().apply {
             putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, call.sid)
             putString(TVBroadcastReceiver.EXTRA_CALL_FROM, call.from ?: "")

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -548,8 +548,7 @@ class TVConnectionService : ConnectionService() {
         val connection = TVCallConnection(applicationContext)
 
         // create Voice SDK call
-        val call = Voice.connect(applicationContext, connectOptions, connection)
-        connection.setCall(call)
+        connection.twilioCall = Voice.connect(applicationContext, connectOptions, connection)
 
         // Resolve call parameters
         val callParams = TVCallParametersImpl(mStorage, connection.twilioCall!!, to, from, params)
@@ -557,6 +556,7 @@ class TVConnectionService : ConnectionService() {
         // Set call state listener, applies non-temporary Call SID when call is ringing or connected (i.e. when assigned by Twilio)
         val onCallStateListener: CompletionHandler<Call.State> = CompletionHandler { state ->
             if (state == Call.State.RINGING || state == Call.State.CONNECTED) {
+                val call = connection.twilioCall!!
                 val callSid = call.sid!!
                 // If call is not attached, attach it
                 if(!activeConnections.containsKey(callSid)) {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -552,7 +552,7 @@ class TVConnectionService : ConnectionService() {
         connection.setCall(call)
 
         // Resolve call parameters
-        val callParams = TVCallParametersImpl(mStorage, call, params)
+        val callParams = TVCallParametersImpl(mStorage, connection.twilioCall!!, to, from, params)
 
         // Set call state listener, applies non-temporary Call SID when call is ringing or connected (i.e. when assigned by Twilio)
         val onCallStateListener: CompletionHandler<Call.State> = CompletionHandler { state ->

--- a/android/src/main/kotlin/com/twilio/twilio_voice/storage/Storage.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/storage/Storage.kt
@@ -32,6 +32,12 @@ interface Storage {
     var defaultCaller: String
 
     /**
+     * If true, reject incoming calls if the app does not have the required permissions. Default is false.
+     * @return true to reject on no permissions, false to ignore.
+     */
+    var rejectOnNoPermissions: Boolean
+
+    /**
      * Get the default caller name, if not set, return the default [Constants.DEFAULT_UNKNOWN_CALLER]
      * @param id: the id of the registered client
      * @return the default caller name

--- a/android/src/main/kotlin/com/twilio/twilio_voice/storage/StorageImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/storage/StorageImpl.kt
@@ -9,6 +9,7 @@ class StorageImpl(ctx: Context) : Storage {
     val TAG: String = javaClass.name
 
     private val kDefaultCaller: String = "defaultCaller"
+    private val kRejectOnNoPermissions: String = "rejectOnNoPermissions"
     private val kShowNotifications: String = "show-notifications"
 
     override var defaultCaller
@@ -17,6 +18,14 @@ class StorageImpl(ctx: Context) : Storage {
         set(value) {
             val editor = prefs.edit()
             editor.putString(kDefaultCaller, value)
+            editor.apply()
+        }
+
+    override var rejectOnNoPermissions
+        get() = prefs.getBoolean(kRejectOnNoPermissions, false)
+        set(value) {
+            val editor = prefs.edit()
+            editor.putBoolean(kRejectOnNoPermissions, value)
             editor.apply()
         }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
@@ -43,7 +43,8 @@ enum class TVMethodChannels(val method: String) {
     @Deprecated("No longer required due to Custom UI replaced with native call screen")
     REQUEST_BACKGROUND_PERMISSIONS("requestBackgroundPermissions"),
     IS_PHONE_ACCOUNT_ENABLED("isPhoneAccountEnabled"),
-    @Deprecated("No longer required due to Custom UI replaced with native call screen")
+    REJECT_CALL_ON_NO_PERMISSIONS("rejectCallOnNoPermissions"),
+    IS_REJECTING_CALL_ON_NO_PERMISSIONS("isRejectingCallOnNoPermissions"),
     UPDATE_CALLKIT_ICON("updateCallKitIcon");
 
     companion object {

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -216,6 +216,30 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
     return Future.value(false);
   }
 
+  /// Reject call when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered.
+  /// If set to true, the call is rejected immediately upon received. If set to false, the call is left until the timeout is reached / call is canceled.
+  /// Defaults to false.
+  ///
+  /// Only available on Android
+  @override
+  Future<bool> rejectCallOnNoPermissions({bool shouldReject = false}) {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return Future.value(true);
+    }
+    return _channel.invokeMethod<bool?>('rejectCallOnNoPermissions', {"shouldReject": shouldReject}).then<bool>((bool? value) => value ?? false);
+  }
+
+  /// Returns true if call is rejected when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered. Defaults to false.
+  ///
+  /// Only available on Android
+  @override
+  Future<bool> isRejectingCallOnNoPermissions() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return Future.value(false);
+    }
+    return _channel.invokeMethod<bool?>('isRejectingCallOnNoPermissions', {}).then<bool>((bool? value) => value ?? false);
+  }
+
   /// Set iOS call kit icon
   ///
   /// This allows for CallKit customization: setting the last button (bottom right) of the callkit.
@@ -273,7 +297,7 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
     } else if (state.startsWith("LOG|PERMISSION|")) {
       List<String> tokens = state.split('|');
       if (kDebugMode) {
-        if(tokens.length == 4) {
+        if (tokens.length == 4) {
           print("Name: ${tokens[2]}, granted state: ${tokens[3]}");
         }
       }
@@ -305,7 +329,8 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
     } else if (state.startsWith("Connected|")) {
       call.activeCall = createCallFromState(state, initiated: true);
       if (kDebugMode) {
-        print('Connected - From: ${call.activeCall!.from}, To: ${call.activeCall!.to}, StartOn: ${call.activeCall!.initiated}, Direction: ${call.activeCall!.callDirection}');
+        print(
+            'Connected - From: ${call.activeCall!.from}, To: ${call.activeCall!.to}, StartOn: ${call.activeCall!.initiated}, Direction: ${call.activeCall!.callDirection}');
       }
       return CallEvent.connected;
     } else if (state.startsWith("Incoming|")) {

--- a/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
@@ -131,6 +131,18 @@ abstract class TwilioVoicePlatform extends SharedPlatformInterface {
   @Deprecated('custom call UI not used anymore, has no effect')
   Future<bool?> requestBluetoothPermissions();
 
+  /// Reject call when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered.
+  /// If set to true, the call is rejected immediately upon received. If set to false, the call is left until the timeout is reached / call is canceled.
+  /// Defaults to false.
+  ///
+  /// Only available on Android
+  Future<bool> rejectCallOnNoPermissions({bool shouldReject = false});
+
+  /// Returns true if call is rejected when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered. Defaults to false.
+  ///
+  /// Only available on Android
+  Future<bool> isRejectingCallOnNoPermissions();
+
   /// Set iOS call kit icon
   ///
   /// This allows for CallKit customization: setting the last button (bottom right) of the callkit.


### PR DESCRIPTION
- Resolve background calls rejecting due to no mic permissions (see commit details)
- Add `rejectCallOnNoPermission` to handle no permissions when call invite is received.