### PR TITLE
Fix Android call direction, details and caller names between call states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * Feat: [Android] Add CallingAccount (Phone Account) label & description via `strings.xml`. @cybex-dev
 * Feat: [Android] Add Calling Account (Phone Account) icon (using current app icon via `getApplicationInfo().getIcon()`). @cybex-dev
 * Fix: request Permissions return result via Flutter future.
+* Fix: [Android] Missing platform method channel for `getSid()`
+* Fix: [Android] Inconsistent caller/recipient names for inbound calls between ringing & connected states.
+* Fix: [Android] Incorrect call direction for incoming calls
 
 ## 0.0.9
 * Feat: forwarded callInvite custom parameters to flutter

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1726,7 +1726,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                     return
                 }
                 val direction = intent.getIntExtra(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, -1)
-                val callDirection = CallDirection.fromId(direction).toString()
+                val callDirection = CallDirection.fromId(direction)!!.label
 //                callSid = callHandle
                 logEvents("", arrayOf("Connected", from, to, callDirection))
             }

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -100,7 +100,8 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
     private var isBluetoothOn: Boolean = false
     private var isMuted: Boolean = false
     private var isHolding: Boolean = false
-    private var callSid: String? = null
+    private val callSid: String?
+        get() = TVConnectionService.getActiveCallHandle()
 
     private var hasStarted = false
 
@@ -1542,7 +1543,6 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
             }
 
             TVBroadcastReceiver.ACTION_ACTIVE_CALL_CHANGED -> {
-                callSid = intent.getStringExtra(TVBroadcastReceiver.EXTRA_CALL_HANDLE)
                 Log.d(TAG, "handleBroadcastIntent: Active call changed to $callSid")
             }
 
@@ -1572,7 +1572,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                         put(key, value)
                     }
                 }.toString()
-                callSid = callHandle
+//                callSid = callHandle
                 logEvents("", arrayOf("Incoming", from, to, CallDirection.INCOMING.label, params))
                 logEvents("", arrayOf("Ringing", from, to, CallDirection.INCOMING.label, params))
             }
@@ -1586,7 +1586,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                         )
                         return
                     }
-                callSid = null
+//                callSid = null
                 Log.d(TAG, "handleBroadcastIntent: Call ended $callHandle")
                 logEvent("", "Call ended")
             }
@@ -1639,7 +1639,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                         put(key, value)
                     }
                 }.toString()
-                callSid = callHandle
+//                callSid = callHandle
                 logEvents("", arrayOf("Answer", from, to, params))
             }
 
@@ -1697,7 +1697,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 val direction = intent.getIntExtra(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, -1)
                 val callDirection = CallDirection.fromId(direction).toString()
 
-                callSid = callHandle
+//                callSid = callHandle
                 logEvents("", arrayOf("Ringing", from, to, callDirection))
             }
 
@@ -1727,7 +1727,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 }
                 val direction = intent.getIntExtra(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, -1)
                 val callDirection = CallDirection.fromId(direction).toString()
-                callSid = callHandle
+//                callSid = callHandle
                 logEvents("", arrayOf("Connected", from, to, callDirection))
             }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
@@ -47,6 +47,20 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
                 ?: resolveHumanReadableName(mToName)
         }
+
+    override val fromRaw: String
+        get() {
+            return mCallInvite.from ?: ""
+        }
+
+    override val toRaw: String
+        get() {
+            return mCallInvite.to
+        }
+
+    override fun toString(): String {
+        return "TVCallInviteParametersImpl(callSid='$callSid', from='$from', fromRaw='$fromRaw' to='$to', toRaw='$toRaw', customParameters=$customParameters)"
+    }
 }
 
 class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFrom: String, customParameters: Map<String, String> = emptyMap()) : TVParametersImpl(storage) {
@@ -102,10 +116,18 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
         }
 
     override val fromRaw: String
-        get() = mFrom
+        get() {
+            return mFrom
+        }
 
     override val toRaw: String
-        get() = mTo
+        get() {
+            return mTo
+        }
+
+    override fun toString(): String {
+        return "TVCallParametersImpl(callSid='$callSid', from='$from', fromRaw='$fromRaw' to='$to', toRaw='$toRaw', customParameters=$customParameters)"
+    }
 }
 
 open class TVParametersImpl(storage: Storage, override val callSid: String = "", override val customParameters: Map<String, String> = emptyMap()) : TVParameters {
@@ -118,20 +140,28 @@ open class TVParametersImpl(storage: Storage, override val callSid: String = "",
     }
 
     override val fromRaw: String
-        get() = ""
+        get() {
+            return ""
+        }
 
     override val from: String
-        get() = customParameters[PARAM_CALLER_NAME]
-            ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
-            ?: mStorage.defaultCaller
+        get() {
+            return customParameters[PARAM_CALLER_NAME]
+                ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
+                ?: mStorage.defaultCaller
+        }
 
     override val toRaw: String
-        get() = ""
+        get() {
+            return ""
+        }
 
     override val to: String
-        get() = customParameters[PARAM_RECIPIENT_NAME]
-            ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
-            ?: mStorage.defaultCaller
+        get() {
+            return customParameters[PARAM_RECIPIENT_NAME]
+                ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
+                ?: mStorage.defaultCaller
+        }
 
     override fun hasCustomParameters(): Boolean {
         return customParameters.isNotEmpty()
@@ -153,5 +183,9 @@ open class TVParametersImpl(storage: Storage, override val callSid: String = "",
     override fun resolveHumanReadableName(name: String): String {
         val id = name.replace("client:", "")
         return mStorage.getRegisteredClient(id) ?: mStorage.defaultCaller
+    }
+
+    override fun toString(): String {
+        return "TVParametersImpl(callSid='$callSid', from='$from', fromRaw='$fromRaw' to='$to', toRaw='$toRaw', customParameters=$customParameters)"
     }
 }

--- a/android/src/main/kotlin/com/twilio/twilio_voice/receivers/TVBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/receivers/TVBroadcastReceiver.kt
@@ -53,9 +53,19 @@ class TVBroadcastReceiver(private val plugin: TwilioVoicePlugin) : BroadcastRece
          */
         const val EXTRA_CALL_HANDLE: String = "EXTRA_CALL_HANDLE"
 
-
+        /**
+         * Extra used providing the call's caller ID.
+         */
         const val EXTRA_CALL_FROM: String = "EXTRA_CALL_FROM"
-        const val EXTRA_CALL_TO: String = "EXTRA_CALL_FROM"
+
+        /**
+         * Extra used providing the call's recipient ID.
+         */
+        const val EXTRA_CALL_TO: String = "EXTRA_CALL_TO"
+
+        /**
+         * Extra used providing the call direction.
+         */
         const val EXTRA_CALL_DIRECTION: String = "EXTRA_CALL_DIRECTION"
 
         /**

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
@@ -12,6 +12,7 @@ import android.telecom.Connection
 import android.telecom.DisconnectCause
 import android.util.Log
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.twilio.twilio_voice.call.TVParameters
 import com.twilio.twilio_voice.receivers.TVBroadcastReceiver
 import com.twilio.twilio_voice.types.CallAudioStateExtension.copyWith
 import com.twilio.twilio_voice.types.CallDirection
@@ -28,6 +29,7 @@ import com.twilio.voice.CallInvite
 class TVCallInviteConnection(
     ctx: Context,
     ci: CallInvite,
+    callParams: TVParameters,
     onEvent: ValueBundleChanged<String>? = null,
     onAction: ValueBundleChanged<String>? = null,
     onDisconnected: CompletionHandler<DisconnectCause>? = null
@@ -39,6 +41,7 @@ class TVCallInviteConnection(
 
     init {
         callInvite = ci
+        setCallParameters(callParams)
     }
 
     override fun onAnswer() {
@@ -93,6 +96,7 @@ open class TVCallConnection(
     var onAction: ValueBundleChanged<String>? = null
     private var onCallStateListener: CompletionHandler<Call.State>? = null
     open val callDirection = CallDirection.OUTGOING
+    private var callParams: TVParameters? = null
 
     init {
         context = ctx
@@ -117,6 +121,14 @@ open class TVCallConnection(
 
     fun setOnCallStateListener(listener: CompletionHandler<Call.State>) {
         onCallStateListener = listener
+    }
+
+    fun setCallParameters(params: TVParameters) {
+        callParams = params
+    }
+
+    fun getCallParameters(): TVParameters? {
+        return callParams
     }
 
     //region Call.Listener
@@ -159,9 +171,9 @@ open class TVCallConnection(
             }
         }
         onEvent?.onChange(TVNativeCallEvents.EVENT_RINGING, Bundle().apply {
-            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, call.sid)
-            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, call.from ?: "")
-            putString(TVBroadcastReceiver.EXTRA_CALL_TO, call.to ?: "")
+            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callParams?.callSid)
+            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, callParams?.fromRaw)
+            putString(TVBroadcastReceiver.EXTRA_CALL_TO, callParams?.toRaw)
             putInt(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, callDirection.id)
         })
         onCallStateListener?.withValue(call.state)
@@ -172,9 +184,9 @@ open class TVCallConnection(
         twilioCall = call
         setActive()
         onEvent?.onChange(TVNativeCallEvents.EVENT_CONNECTED, Bundle().apply {
-            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, call.sid)
-            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, call.from ?: "")
-            putString(TVBroadcastReceiver.EXTRA_CALL_TO, call.to ?: "")
+            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callParams?.callSid)
+            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, callParams?.fromRaw)
+            putString(TVBroadcastReceiver.EXTRA_CALL_TO, callParams?.toRaw)
             putInt(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, callDirection.id)
         })
         onCallStateListener?.withValue(call.state)
@@ -194,9 +206,9 @@ open class TVCallConnection(
     override fun onReconnecting(call: Call, callException: CallException) {
         twilioCall = call
         onEvent?.onChange(TVNativeCallEvents.EVENT_RECONNECTING, Bundle().apply {
-            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, call.sid)
-            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, call.from ?: "")
-            putString(TVBroadcastReceiver.EXTRA_CALL_TO, call.to ?: "")
+            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callParams?.callSid)
+            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, callParams?.fromRaw)
+            putString(TVBroadcastReceiver.EXTRA_CALL_TO, callParams?.toRaw)
             putInt(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, callDirection.id)
             putExtras(callException.toBundle())
         })
@@ -212,11 +224,11 @@ open class TVCallConnection(
         twilioCall = call
         setActive()
         onEvent?.onChange(TVNativeCallEvents.EVENT_RECONNECTED, Bundle().apply {
-            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, call.sid)
-            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, call.from ?: "")
-            putString(TVBroadcastReceiver.EXTRA_CALL_TO, call.to ?: "")
+            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callParams?.callSid)
+            putString(TVBroadcastReceiver.EXTRA_CALL_FROM, callParams?.fromRaw)
+            putString(TVBroadcastReceiver.EXTRA_CALL_TO, callParams?.toRaw)
             putInt(TVBroadcastReceiver.EXTRA_CALL_DIRECTION, callDirection.id)
-        })
+        });
         onCallStateListener?.withValue(call.state)
     }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -178,12 +178,15 @@ class TVConnectionService : ConnectionService() {
         }
 
         /**
-         * Get the first active call handle, if any. Returns null if there are no active calls. If there are more than one active calls, the first call handle is returned.
+         * Active call definition is extended to include calls in which one can actively communicate, or call is on hold, or call is ringing or dialing. This applies only to this and calling functions.
+         * Gets the first ongoing call handle, if any. Else, gets the first call on hold. Lastly, gets the first call in either a ringing or dialing state, if any. Returns null if there are no active calls. If there are more than one active calls, the first call handle is returned.
          * Note: this might not necessarily correspond to the current active call.
          */
         fun getActiveCallHandle(): String? {
             if (!hasActiveCalls()) return null
             return activeConnections.entries.firstOrNull { it.value.state == Connection.STATE_ACTIVE }?.key
+                ?: activeConnections.entries.firstOrNull { it.value.state == Connection.STATE_HOLDING }?.key
+                ?: activeConnections.entries.firstOrNull { arrayListOf(Connection.STATE_RINGING, Connection.STATE_DIALING).contains(it.value.state) }?.key
         }
 
         fun getIncomingCallHandle(): String? {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
@@ -10,7 +10,7 @@ enum class TVMethodChannels(val method: String) {
     IS_BLUETOOTH_ON("isBluetoothOn"),
     TOGGLE_MUTE("toggleMute"),
     IS_MUTED("isMuted"),
-    CALL_SID("callSid"),
+    CALL_SID("call-sid"),
     IS_ON_CALL("isOnCall"),
     HOLD_CALL("holdCall"),
     IS_HOLDING("isHolding"),

--- a/example/lib/screens/widgets/on_call_widget.dart
+++ b/example/lib/screens/widgets/on_call_widget.dart
@@ -1,27 +1,113 @@
 import 'package:flutter/material.dart';
 import 'package:twilio_voice/twilio_voice.dart';
 
-class OnCallWidget extends StatelessWidget {
+class OnCallWidget extends StatefulWidget {
   const OnCallWidget({super.key});
 
   @override
+  State<OnCallWidget> createState() => _OnCallWidgetState();
+}
+
+class _OnCallWidgetState extends State<OnCallWidget> {
+  final List<CallEvent> _events = [];
+
+  /// Store only call-related events
+  void _addEvent(CallEvent? event) {
+    if (event == null) return;
+    switch (event) {
+      case CallEvent.incoming:
+      case CallEvent.ringing:
+      case CallEvent.connected:
+      case CallEvent.callEnded:
+      case CallEvent.declined:
+      case CallEvent.answer:
+      case CallEvent.missedCall:
+      case CallEvent.returningCall:
+        _events.add(event);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /// Build 'On Call' status indicator
+  Widget _buildOnCallStatus({bool onCall = false}) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _StatusIcon(active: onCall),
+        const SizedBox(width: 8),
+        Text(onCall ? "On Call" : "Not on call", style: Theme.of(context).textTheme.bodyMedium),
+      ],
+    );
+  }
+
+  /// Build 'table' containing call details: from, to, direction, sid, call state
+  Widget _buildCallDetails(ActiveCall? activeCall) {
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        // Labels
+        const Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [Text("From:"), Text("To:"), Text("Direction:"), Text("SID:"), Text("State:")],
+        ),
+
+        // Spacer
+        const SizedBox(width: 8),
+
+        // Content/labels/stats
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(activeCall?.fromFormatted ?? "N/A"),
+              Text(activeCall?.toFormatted ?? "N/A"),
+              activeCall != null ? Text(activeCall.callDirection == CallDirection.incoming ? "Incoming" : "Outgoing") : const Text("N/A"),
+              _CallSID(),
+              _events.isEmpty ? const Text("N/A") : Text(_events.last.toString()),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return StreamBuilder(
+    return StreamBuilder<CallEvent>(
       stream: TwilioVoice.instance.callEventsListener,
       builder: (context, snapshot) {
+        _addEvent(snapshot.data);
         return FutureBuilder<bool>(
           future: TwilioVoice.instance.call.isOnCall(),
           builder: (context, snapshot) {
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.center,
+            final activeCall = TwilioVoice.instance.call.activeCall;
+            return Column(
               children: [
-                _StatusIcon(active: snapshot.data ?? false),
-                const SizedBox(width: 8),
-                Text(snapshot.data == true ? "On Call" : "Not on call", style: Theme.of(context).textTheme.bodyMedium),
+                _buildOnCallStatus(onCall: snapshot.data == true),
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+                  child: _buildCallDetails(activeCall),
+                )
               ],
             );
           },
         );
+      },
+    );
+  }
+}
+
+class _CallSID extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: TwilioVoice.instance.call.getSid(),
+      builder: (context, snapshot) {
+        final sid = snapshot.data ?? "N/A";
+        return Text(sid);
       },
     );
   }


### PR DESCRIPTION
Resolved/fixed:
- Inconsistent naming between inbound call states
- Incorrect call direction for inbound calls
- `getSid` method channel implementation missing