### PR TITLE
Call ringing outgoing direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Fix: [Android] Missing platform method channel for `getSid()`
 * Fix: [Android] Inconsistent caller/recipient names for inbound calls between ringing & connected states.
 * Fix: [Android] Incorrect call direction for incoming calls
+* Fix: call ringing event always showing `CallDirection.outgoing`
 
 ## 0.0.9
 * Feat: forwarded callInvite custom parameters to flutter

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -343,7 +343,7 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
 
       return CallEvent.incoming;
     } else if (state.startsWith("Ringing|")) {
-      call.activeCall = createCallFromState(state, callDirection: CallDirection.outgoing);
+      call.activeCall = createCallFromState(state);
 
       if (kDebugMode) {
         print('Ringing - From: ${call.activeCall!.from}, To: ${call.activeCall!.to}, Direction: ${call.activeCall!.callDirection}');


### PR DESCRIPTION
Resolved building active call on ringing event has hard-coded outgoing direction, now resolves the direction from parameters.

This allows ringing event to be used to indicate a call is ringing on the recipient side (see `answerOnBridge`) or to indicate a pending incoming call.