### PR TITLE
Fix name resolution priority and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Fix: [Android] Inconsistent caller/recipient names for inbound calls between ringing & connected states.
 * Fix: [Android] Incorrect call direction for incoming calls
 * Fix: call ringing event always showing `CallDirection.outgoing`
+* Fix: [Android] Updated CallKit incoming/outgoing name parameter resolution
 
 ## 0.0.9
 * Feat: forwarded callInvite custom parameters to flutter

--- a/README.md
+++ b/README.md
@@ -332,12 +332,23 @@ Caller is usually referred to as `call.from` or `callInvite.from`. This can eith
 
 The following rules are applied to determine the caller/recipient name, which is shown in the call screen and heads-up notification:
 
-- If the caller is empty/not provided, the default caller name is shown e.g. "Unknown Caller", else
-- if the caller is a number, the plugin will show the number as is, else
-- if the caller is a string, the plugin will interpret the string as follows:
-  - if the `__TWI_CALLER_NAME` parameter is provided, the plugin will show the value of `__TWI_CALLER_NAME` as is, else
-  - if the `__TWI_CALLER_ID` parameter is provided, the plugin will search for a registered client with the same id and show the client name, else
-  - if not found or not provided, the plugin will search for a registered client with the `call.from` value and show the client name, as a last resort
+##### Incoming Calls:
+
+`__TWI_CALLER_NAME` -> `resolve(__TWI_CALLER_ID)` -> (phone number) -> `registered client (from)` -> `defaultCaller name` -> `"Unknown Caller"`
+
+
+##### Outgoing Calls:
+
+`__TWI_RECIPIENT_NAME` -> `resolve(__TWI_RECIPIENT_ID)` -> (phone number) -> `registered client (to)` -> `defaultCaller name` -> `"Unknown Caller"`
+
+**Details explaination:**
+
+- if the call is an CallInvite (incoming), the plugin will interpret the string as follows or if the call is outgoing, the twilio `To` parameter field is used to:
+  - if the `__TWI_CALLER_NAME` (or `__TWI_RECIPIENT_NAME`) parameter is provided, the plugin will show the value of `__TWI_CALLER_NAME` (or `__TWI_RECIPIENT_NAME`) as is, else
+  - if the `__TWI_CALLER_ID` (or `__TWI_RECIPIENT_ID`) parameter is provided, the plugin will search for a registered client with the same id and show the client name,
+- if the caller (`from` or `to` fields) is empty/not provided, the default caller name is shown e.g. "Unknown Caller", else
+- else if the caller (`from` or `to` fields) is a number, the plugin will show the number as is, else
+- else the plugin will search for a registered client with the `callInvite.from` (or call.to) value and show the client name, as a last resort
   - the default caller name is shown e.g. "Unknown Caller"
 
 *Please note: the same approach applies to both caller and recipient name resolution.*

--- a/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
@@ -18,14 +18,14 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
 
     override val from: String
         get() {
-            val mFrom = mCallInvite.from ?: ""
-            if (mFrom.isEmpty()) {
-                return mStorage.defaultCaller
-            }
-
             return customParameters[PARAM_CALLER_NAME]
                 ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
                 ?: run {
+                    val mFrom = mCallInvite.from ?: ""
+                    if (mFrom.isEmpty()) {
+                        return mStorage.defaultCaller
+                    }
+
                     if (!mFrom.startsWith("client:")) {
                         // we have a number, return as is
                         return mFrom
@@ -38,11 +38,11 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
 
     override val to: String
         get() {
-            val mTo = mCallInvite.to
-
             return customParameters[PARAM_RECIPIENT_NAME]
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
                 ?: run {
+                    val mTo = mCallInvite.to
+
                     if (!mTo.startsWith("client:")) {
                         // we have a number, return as is
                         return mTo
@@ -88,13 +88,13 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
 
     override val from: String
         get() {
-            if (mFrom.isEmpty()) {
-                return mStorage.defaultCaller
-            }
-
             return customParameters[PARAM_CALLER_NAME]
                 ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
                 ?: run {
+                    if (mFrom.isEmpty()) {
+                        return mStorage.defaultCaller
+                    }
+
                     if (!mFrom.startsWith("client:")) {
                         // we have a number, return as is
                         return mFrom
@@ -107,13 +107,13 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
 
     override val to: String
         get() {
-            if (mTo.isEmpty()) {
-                return mStorage.defaultCaller
-            }
-
             return customParameters[PARAM_RECIPIENT_NAME]
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
                 ?: run {
+                    if (mTo.isEmpty()) {
+                        return mStorage.defaultCaller
+                    }
+
                     if (!mTo.startsWith("client:")) {
                         // we have a number, return as is
                         return mTo

--- a/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
@@ -23,29 +23,34 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
                 return mStorage.defaultCaller
             }
 
-            if (!mFrom.startsWith("client:")) {
-                // we have a number, return as is
-                return mFrom
-            }
-
-            val mToName = mFrom.replace("client:", "")
             return customParameters[PARAM_CALLER_NAME]
                 ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
-                ?: resolveHumanReadableName(mToName)
+                ?: run {
+                    if (!mFrom.startsWith("client:")) {
+                        // we have a number, return as is
+                        return mFrom
+                    }
+
+                    val mToName = mFrom.replace("client:", "")
+                    return resolveHumanReadableName(mToName)
+                }
         }
 
     override val to: String
         get() {
             val mTo = mCallInvite.to
-            if (!mTo.startsWith("client:")) {
-                // we have a number, return as is
-                return mTo
-            }
 
-            val mToName = mTo.replace("client:", "")
             return customParameters[PARAM_RECIPIENT_NAME]
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
-                ?: resolveHumanReadableName(mToName)
+                ?: run {
+                    if (!mTo.startsWith("client:")) {
+                        // we have a number, return as is
+                        return mTo
+                    }
+
+                    val mToName = mTo.replace("client:", "")
+                    return resolveHumanReadableName(mToName)
+                }
         }
 
     override val fromRaw: String
@@ -87,15 +92,17 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
                 return mStorage.defaultCaller
             }
 
-            if (!mFrom.startsWith("client:")) {
-                // we have a number, return as is
-                return mFrom
-            }
-
-            val mFromName = mFrom.replace("client:", "")
             return customParameters[PARAM_CALLER_NAME]
                 ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
-                ?: resolveHumanReadableName(mFromName)
+                ?: run {
+                    if (!mFrom.startsWith("client:")) {
+                        // we have a number, return as is
+                        return mFrom
+                    }
+
+                    val mFromName = mFrom.replace("client:", "")
+                    return resolveHumanReadableName(mFromName)
+                }
         }
 
     override val to: String
@@ -104,15 +111,17 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
                 return mStorage.defaultCaller
             }
 
-            if (!mTo.startsWith("client:")) {
-                // we have a number, return as is
-                return mTo
-            }
-
-            val mToName = mTo.replace("client:", "")
             return customParameters[PARAM_RECIPIENT_NAME]
                 ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
-                ?: resolveHumanReadableName(mToName)
+                ?: run {
+                    if (!mTo.startsWith("client:")) {
+                        // we have a number, return as is
+                        return mTo
+                    }
+
+                    val mToName = mTo.replace("client:", "")
+                    return resolveHumanReadableName(mToName)
+                }
         }
 
     override val fromRaw: String

--- a/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/call/TVParametersImpl.kt
@@ -29,8 +29,8 @@ class TVCallInviteParametersImpl(storage: Storage, callInvite: CallInvite) : TVP
             }
 
             val mToName = mFrom.replace("client:", "")
-            return customParameters[PARAM_RECIPIENT_NAME]
-                ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
+            return customParameters[PARAM_CALLER_NAME]
+                ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
                 ?: resolveHumanReadableName(mToName)
         }
 
@@ -93,8 +93,8 @@ class TVCallParametersImpl(storage: Storage, call: Call, callTo: String, callFro
             }
 
             val mFromName = mFrom.replace("client:", "")
-            return customParameters[PARAM_RECIPIENT_NAME]
-                ?: customParameters[PARAM_RECIPIENT_ID]?.let { resolveHumanReadableName(it) }
+            return customParameters[PARAM_CALLER_NAME]
+                ?: customParameters[PARAM_CALLER_ID]?.let { resolveHumanReadableName(it) }
                 ?: resolveHumanReadableName(mFromName)
         }
 


### PR DESCRIPTION
- Fix custom parameter keys
- Updated `from` or `to` name resolution priority for CallKit showing custom parameters fields first.