### PR TITLE
Fix: Android `unregister()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added: CallEvents: 
   * `Reconnected`
   * `Reconnecting`
+* Fix: [Android] Fix `unregister()` from Twilio (assign internal device token)
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * `Reconnected`
   * `Reconnecting`
 * Fix: [Android] Fix `unregister()` from Twilio (assign internal device token)
+* Update: example with logout action
 
 ## 0.1.1
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -355,6 +355,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
 
                 Log.d(TAG, "Setting up token")
                 this.accessToken = accessToken
+                this.fcmToken = deviceToken;
 
                 Log.d(TAG, "Registering for call events")
                 registerForCallInvites(accessToken, deviceToken)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -324,6 +324,24 @@ class _AppState extends State<App> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Plugin example app"),
+        actions: [
+          _LogoutAction(
+            onSuccess: () {
+              setState(() {
+                twilioInit = false;
+              });
+            },
+            onFailure: (error) {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text("Error"),
+                  content: Text("Failed to unregister from calls: $error"),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: SafeArea(
         child: Center(
@@ -389,5 +407,27 @@ class _AppState extends State<App> {
         );
       },
     );
+  }
+}
+
+class _LogoutAction extends StatelessWidget {
+  final void Function()? onSuccess;
+  final void Function(String error)? onFailure;
+
+  const _LogoutAction({Key? key, this.onSuccess, this.onFailure}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+        onPressed: () async {
+          final result = await TwilioVoice.instance.unregister();
+          if (result == true) {
+            onSuccess?.call();
+          } else {
+            onFailure?.call("Failed to unregister");
+          }
+        },
+        label: const Text("Logout", style: TextStyle(color: Colors.white)),
+        icon: const Icon(Icons.logout, color: Colors.white));
   }
 }


### PR DESCRIPTION
Device token is provided on `register(String, String)` but never stored internally to unregister.