### PR TITLE
[Feat] Add missing manage own calls Android permission 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * `Reconnected`
   * `Reconnecting`
 * Fix: [Android] Fix `unregister()` from Twilio (assign internal device token)
+* Update: [Android] Add `MANGE_OWN_CALLS` permission to manifest, method channel implementation & example update, see discussion [here](https://github.com/cybex-dev/twilio_voice/issues/194).
 * Update: example with logout action, new `CallEvent`s
 
 ## 0.1.1

--- a/NOTES.md
+++ b/NOTES.md
@@ -26,6 +26,11 @@ Required for reading phone numbers (e.g. for Telecom App), this is required to c
 * `android.permission.CALL_PHONE`
 Required for `ConnectionService` to interact with the `TelecomManager` to place outgoing calls.
 
+* `android.permission.MANAGE_OWN_CALLS`
+  * Required for `ConnectionService` to interact with the `TelecomManager` to receive incoming calls.
+  * According to Android documentation, this permission is only required for self-managed `ConnectionService`'s, however it seems to be required for system-managed `ConnectionService`'s as well (atleast on Android 13 and lower).
+  * Finally, this permission seems to be required to place outgoing calls on Android 13 and lower, if not will result `java.lang.SecurityException: Self-managed ConnectionServices require MANAGE_OWN_CALLS permission.`
+
 #### ConnectionService integration
  There are a few (additional) permissions added to use the [system-managed `ConnectionService`](https://developer.android.com/reference/android/telecom/ConnectionService), several permissions are required to enable this functionality (see example app). These permissions  `android.permission.READ_PHONE_STATE`, `android.permission.READ_PHONE_NUMBERS`, `android.permission.RECORD_AUDIO` and `android.permission.CALL_PHONE` have already been added to the package, you do not have to add them. Finally, a [PhoneAccount] is required to interact with the `ConnectionService`, this is discussed in more detail below.
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Similar to CallKit on iOS, Android implements their own via a [ConnectionService
 TwilioVoice.instance.requestCallPhonePermission();  // Gives Android permissions to place outgoing calls
 TwilioVoice.instance.requestReadPhoneStatePermission();  // Gives Android permissions to read Phone State including receiving calls
 TwilioVoice.instance.requestReadPhoneNumbersPermission();  // Gives Android permissions to read Phone Accounts
+TwilioVoice.instance.requestManageOwnCallsPermission();  // Gives Android permissions to manage calls, this isn't necessary to request as the permission is simply required in the Manifest, but added nontheless.
 ```
 
 Following this, to register a Phone Account (required by all applications implementing a system-managed `ConnectionService`, run:
@@ -514,6 +515,8 @@ TwilioVoice.instance.isRejectingCallOnNoPermissions(); // Checks if the plugin i
 ```
 
 If the `CALL_PHONE` permissions group i.e. `READ_PHONE_STATE`, `READ_PHONE_NUMBERS`, `CALL_PHONE` aren't granted nor a Phone Account is registered and enabled, the plugin will either reject the incoming call (true) or not show the incoming call UI (false).
+
+_Note: If `MANAGE_OWN_CALLS` permission is not granted, outbound calls will not work._
 
 See [Android Setup](#android-setup) and [Android Notes](https://github.com/diegogarciar/twilio_voice/blob/master/NOTES.md#android) for more information regarding configuring the `ConnectionService` and registering a Phone Account.
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <application>

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1065,6 +1065,10 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 Log.e(TAG, "No call phone permission, call `requestCallPhonePermission()` first")
                 return false
             }
+            if (!checkManageOwnCallsPermission()) {
+                Log.e(TAG, "No manage own calls permission, call `requestManageOwnCallsPermission()` first")
+                return false
+            }
 
             val callParams = HashMap<String, String>(params)
             if (params[Constants.PARAM_TO] == null) {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -27,6 +27,7 @@ import com.twilio.twilio_voice.types.CallDirection
 import com.twilio.twilio_voice.types.CompletionHandler
 import com.twilio.twilio_voice.types.ContextExtension.appName
 import com.twilio.twilio_voice.types.ContextExtension.hasCallPhonePermission
+import com.twilio.twilio_voice.types.ContextExtension.hasManageOwnCallsPermission
 import com.twilio.twilio_voice.types.IntentExtension.getParcelableExtraSafe
 import com.twilio.twilio_voice.types.TelecomManagerExtension.getPhoneAccountHandle
 import com.twilio.twilio_voice.types.TelecomManagerExtension.hasCallCapableAccount
@@ -395,6 +396,11 @@ class TVConnectionService : ConnectionService() {
 
                     if (!applicationContext.hasCallPhonePermission()) {
                         Log.e(TAG, "onStartCommand: Missing CALL_PHONE permission, request permission with `requestCallPhonePermission()`")
+                        return@let
+                    }
+
+                    if (!applicationContext.hasManageOwnCallsPermission()) {
+                        Log.e(TAG, "onStartCommand: Missing MANAGE_OWN_CALLS permission, request permission with `requestManageOwnCallsPermission()`")
                         return@let
                     }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/ContextExtension.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/ContextExtension.kt
@@ -44,6 +44,14 @@ object ContextExtension {
     }
 
     /**
+     * Check if the app has the MANAGE_OWN_CALLS permission
+     * @return Boolean True if the app has the MANAGE_OWN_CALLS permission
+     */
+    fun Context.hasManageOwnCallsPermission(): Boolean {
+        return checkPermission(android.Manifest.permission.MANAGE_OWN_CALLS)
+    }
+
+    /**
      * Check if the app has the CALL_PHONE permission
      * @return Boolean True if the app has the CALL_PHONE permission
      */

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
@@ -37,6 +37,8 @@ enum class TVMethodChannels(val method: String) {
     BACKGROUND_CALL_UI("backgroundCallUi"),
     SHOW_NOTIFICATIONS("showNotifications"),
     HAS_READ_PHONE_NUMBERS_PERMISSION("hasReadPhoneNumbersPermission"),
+    HAS_MANAGE_OWN_CALLS_PERMISSION("hasManageOwnCallsPermission"),
+    REQUEST_MANAGE_OWN_CALLS_PERMISSION("requestManageOwnCallsPermission"),
     @Deprecated("No longer required due to Custom UI replaced with native call screen")
     REQUIRES_BACKGROUND_PERMISSIONS("requiresBackgroundPermissions"),
     REQUEST_READ_PHONE_NUMBERS_PERMISSION("requestReadPhoneNumbersPermission"),

--- a/example/lib/screens/widgets/permissions_block.dart
+++ b/example/lib/screens/widgets/permissions_block.dart
@@ -52,6 +52,14 @@ class _PermissionsBlockState extends State<PermissionsBlock> with WidgetsBinding
     });
   }
 
+  bool _hasManageCallsPermission = false;
+
+  set setManageCallsPermission(bool value) {
+    setState(() {
+      _hasManageCallsPermission = value;
+    });
+  }
+
   bool _isPhoneAccountEnabled = false;
 
   set setIsPhoneAccountEnabled(bool value) {
@@ -198,6 +206,7 @@ class _PermissionsBlockState extends State<PermissionsBlock> with WidgetsBinding
       FirebaseMessaging.instance.requestPermission().then((value) => setBackgroundPermission = value.authorizationStatus == AuthorizationStatus.authorized);
     }
     _tv.hasCallPhonePermission().then((value) => setCallPhonePermission = value);
+    _tv.hasManageOwnCallsPermission().then((value) => setManageCallsPermission = value);
     _tv.hasRegisteredPhoneAccount().then((value) => setPhoneAccountRegistered = value);
     _tv.isPhoneAccountEnabled().then((value) => setIsPhoneAccountEnabled = value);
   }
@@ -324,6 +333,18 @@ class _PermissionsBlockState extends State<PermissionsBlock> with WidgetsBinding
                   onRequestPermission: () async {
                     await _tv.requestCallPhonePermission();
                     setCallPhonePermission = await _tv.hasCallPhonePermission();
+                  },
+                ),
+
+              // if android
+              if (!kIsWeb && Platform.isAndroid)
+                PermissionTile(
+                  icon: Icons.call_received,
+                  title: "Manage Calls",
+                  granted: _hasManageCallsPermission,
+                  onRequestPermission: () async {
+                    await _tv.requestManageOwnCallsPermission();
+                    setManageCallsPermission = await _tv.hasManageOwnCallsPermission();
                   },
                 ),
 

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -180,6 +180,28 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
     return _channel.invokeMethod('requestCallPhonePermission', {});
   }
 
+  /// Checks if device has permission to manage system calls
+  ///
+  /// Android only
+  @override
+  Future<bool> hasManageOwnCallsPermission() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return Future.value(true);
+    }
+    return _channel.invokeMethod<bool?>('hasManageOwnCallsPermission', {}).then<bool>((bool? value) => value ?? false);
+  }
+
+  /// Requests system permission to manage calls
+  ///
+  /// Android only
+  @override
+  Future<bool?> requestManageOwnCallsPermission() {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return Future.value(true);
+    }
+    return _channel.invokeMethod('requestManageOwnCallsPermission', {});
+  }
+
   /// Checks if device has read phone numbers permission
   ///
   /// Android only

--- a/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
@@ -106,6 +106,16 @@ abstract class TwilioVoicePlatform extends SharedPlatformInterface {
   /// Android only
   Future<bool?> requestCallPhonePermission();
 
+  /// Checks if device has permission to manage system calls
+  ///
+  /// Android only
+  Future<bool> hasManageOwnCallsPermission();
+
+  /// Requests system permission to manage calls
+  ///
+  /// Android only
+  Future<bool?> requestManageOwnCallsPermission();
+
   /// Checks if device has read phone numbers permission
   ///
   /// Android only


### PR DESCRIPTION
According to Android documentation, the `MANAGE_OWN_CALLS` permission isn't required for system-managed `ConnectionService` APIs.

The Android system however requires the permission for Android 13 and lower. If not provided (atleast declared in `AndroidManifest.xml`), the app crashes with a `SecurityException`.

Changes include:
- Update to Android Manifest
- Add native implementation, and safety catch for security exception
- Add method channel implementation
- Update example