### PR TITLE
fix(call account):one plus call account setting is missing

### DIFF
--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TelecomManagerExtension.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TelecomManagerExtension.kt
@@ -60,7 +60,7 @@ object TelecomManagerExtension {
     }
 
     fun TelecomManager.openPhoneAccountSettings(activity: Activity) {
-        if (Build.MANUFACTURER.equals("Samsung", ignoreCase = true)) {
+        if (Build.MANUFACTURER.equals("Samsung", ignoreCase = true)|| Build.MANUFACTURER.equals("OnePlus", ignoreCase = true)) {
             try {
                 val intent = Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS)
                 intent.component = ComponentName(


### PR DESCRIPTION
phone account settings were missing in Oneplus devices just like the Samsung, so I added the exact same checking for one plus along with Samsung , please let me know if there any change required 