### PR TITLE
Fixes: iOS foreground notification display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next Release
+
+* Fix: [iOS] Notifications not showing when app is in foreground.
+
 ## 0.3.1
 
 * Fix: [iOS] Fix `hangUp()` not ending incoming call when call is ringing. [Issue #244](https://github.com/cybex-dev/twilio_voice/issues/244)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -75,6 +75,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         voipRegistry.delegate = self
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
+        
+        UNUserNotificationCenter.current().delegate = self
 
         let appDelegate = UIApplication.shared.delegate
         guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {


### PR DESCRIPTION
Fixes an issue where notifications are not displayed when the application is in the foreground on iOS.

The plugin now sets itself as the notification center delegate to ensure notifications are properly handled in all app states.