### PR TITLE
Fixes: Adds missing deviceToken to CallEvent on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Release
 
+* Fix: [iOS] Add missing `deviceToken` when reporting 'DEVICETOKEN' `CallEvent`. [Issue #241](https://github.com/cybex-dev/twilio_voice/issues/241)
 * Fix: [iOS] Notifications not showing when app is in foreground.
 
 ## 0.3.1

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -735,7 +735,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "LOG|Call failed to connect: \(error.localizedDescription)", isError: false)
         self.sendPhoneCallEvents(description: "Call Ended", isError: false)
         if(error.localizedDescription.contains("Access Token expired")){
-            self.sendPhoneCallEvents(description: "DEVICETOKEN", isError: false)
+            if let deviceToken = deviceToken {
+                self.sendPhoneCallEvents(description: "DEVICETOKEN|\(String(decoding: deviceToken, as: UTF8.self))", isError: false)
+            }
         }
         if let completion = self.callKitCompletionCallback {
             completion(false)


### PR DESCRIPTION
Addresses an issue where the `deviceToken` was missing when reporting 'DEVICETOKEN' `CallEvent` on iOS.

Fixes #241