### PR TITLE
Fixes iOS Missed Call Notification Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next release
+
+* Fix: [iOS] Missed call notifications now show caller name (or full number) on title, and "Missed call" text in body. [Issue #299](https://github.com/cybex-dev/twilio_voice/issues/299)
+* Docs: update CHANGELOG
+
 ## 0.3.2
 
 * Fix: [iOS] Add missing `deviceToken` when reporting 'DEVICETOKEN' `CallEvent`. [Issue #241](https://github.com/cybex-dev/twilio_voice/issues/241)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -682,7 +682,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
             
             let title = userName ?? self.clients["defaultCaller"] ?? self.defaultCaller
-            content.title = String(format:  NSLocalizedString("notification_missed_call", comment: ""),title)
+            content.title = title
 
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
             let request = UNNotificationRequest(identifier: UUID().uuidString,

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -683,6 +683,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             
             let title = userName ?? self.clients["defaultCaller"] ?? self.defaultCaller
             content.title = title
+            content.body = NSLocalizedString("notification_missed_call_body", comment: "")
 
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
             let request = UNNotificationRequest(identifier: UUID().uuidString,


### PR DESCRIPTION
Updates iOS missed call notifications to:

- Display the caller's name (or number) in the title.
- Show "Missed call" text in the notification body.

This change improves the clarity and informativeness of missed call notifications on iOS devices.

Fixes #299